### PR TITLE
Fix default value in tparams

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## [UNRELEASED]
+
+### Fix
+
+- Incorrect parameter name of template (#170)
+
 ## [0.7.2]
 
 ### Fix

--- a/package.json
+++ b/package.json
@@ -254,7 +254,7 @@
   },
   "devDependencies": {
     "@types/mocha": "^5.2.7",
-    "@types/node": "^12.7.1",
+    "@types/node": "12.7.1",
     "decache": "^4.5.1",
     "handlebars": "^4.7.3",
     "istanbul": "^0.4.5",

--- a/src/Lang/Cpp/CppParser.ts
+++ b/src/Lang/Cpp/CppParser.ts
@@ -808,6 +808,9 @@ export default class CppParser implements ICodeParser {
         // Remove <> and add a comma to the end to remove edge case.
         template = template.slice(template.indexOf("<") + 1, template.lastIndexOf(">")).replace(/^\s+|\s+$/g, "") + ",";
 
+        // Remove = and everything to the right until a , comes up
+        template = template.replace(/(\W*=\W*\S*\,)/gm, ",")
+
         const nestedCounts: { [key: string]: number; } = {
             "(": 0,
             "<": 0,

--- a/src/Lang/Cpp/CppParser.ts
+++ b/src/Lang/Cpp/CppParser.ts
@@ -809,7 +809,7 @@ export default class CppParser implements ICodeParser {
         template = template.slice(template.indexOf("<") + 1, template.lastIndexOf(">")).replace(/^\s+|\s+$/g, "") + ",";
 
         // Remove = and everything to the right until a , comes up
-        template = template.replace(/(\W*=\W*\S*\,)/gm, ",")
+        template = template.replace(/(\W*=\W*\S*\,)/gm, ",");
 
         const nestedCounts: { [key: string]: number; } = {
             "(": 0,

--- a/src/test/CppTests/Templates.test.ts
+++ b/src/test/CppTests/Templates.test.ts
@@ -48,4 +48,11 @@ suite("C++ - Template tests", () => {
         assert.equal("/**\n * @brief \n * \n * @tparam T \n * @tparam Args \n *"
             + " @param first \n * @param args \n * @return T \n */", result);
     });
+
+    test("Default template param value", () => {
+        const result = testSetup.SetLine("template <bool is_foo=false, bool is_bar =true, bool is_nothrow = true>"
+            + "\nstruct Foo;").GetResult();
+        assert.equal("/**\n * @brief \n * \n * @tparam is_foo \n * @tparam is_bar \n *"
+            + " @tparam is_nothrow \n */", result);
+    });
 });


### PR DESCRIPTION
# Fix

## Fix

- [x] Link to issue. If there is no issue please describe it using at least the issue template

- [x] Description of the fix

- [x] Added unit test

Fixes #170 

The `tparam` check is checking for whitespaces. Many code styles surround `=` with whitespaces and here the detection fails.