### PR TITLE
Add custom tags to generic order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## [UNRELEASED]
+
+### Feature
+
+- Support for arbitrary tags (#169)
+
 ## [0.7.2]
 
 ### Fix

--- a/README.md
+++ b/README.md
@@ -199,8 +199,12 @@ Each of them can be configured with its own custom text and you can decide if th
     "empty",
     "tparam",
     "param",
-    "return"
+    "return",
+    "custom"
   ],
+
+  // Custom tags to be added to the generic order. One tag per line will be added. You have to specify the prefix yourself.
+  "doxdocgen.generic.customTags": [],
 
   // The template of the param Doxygen line(s) that are generated. If empty it won't get generated at all.
   "doxdocgen.generic.paramTemplate": "@param {param} ",

--- a/package.json
+++ b/package.json
@@ -214,7 +214,17 @@
             "empty",
             "tparam",
             "param",
-            "return"
+            "return",
+            "custom"
+          ]
+        },
+        "doxdocgen.generic.customTags": {
+          "description": "Custom tags to be added to the generic order. One tag per line will be added. You have to specify the prefix yourself.",
+          "type": [
+            "array",
+            "string"
+          ],
+          "default": [
           ]
         },
         "doxdocgen.generic.filteredKeywords": {

--- a/src/Config.ts
+++ b/src/Config.ts
@@ -57,6 +57,7 @@ class Generic {
     public generateSmartText: boolean = true;
     public splitCasingSmartText: boolean = true;
     public order: string[] = ["brief", "empty", "tparam", "param", "return"];
+    public customTags: string[] = [];
     public filteredKeywords: string[] = [];
 }
 
@@ -96,6 +97,7 @@ export class Config {
         values.Generic.generateSmartText = Generic.getConfiguration().get<boolean>("generateSmartText", values.Generic.generateSmartText);
         values.Generic.splitCasingSmartText = Generic.getConfiguration().get<boolean>("splitCasingSmartText", values.Generic.splitCasingSmartText);
         values.Generic.order = Generic.getConfiguration().get<string[]>("order", values.Generic.order);
+        values.Generic.customTags = Generic.getConfiguration().get<string[]>("customTags", values.Generic.customTags);
         values.Generic.filteredKeywords = Generic.getConfiguration().get<string[]>("filteredKeywords", values.Generic.filteredKeywords);
 
         return values;

--- a/src/Lang/Cpp/CppDocGen.ts
+++ b/src/Lang/Cpp/CppDocGen.ts
@@ -449,9 +449,17 @@ export class CppDocGen implements IDocGen {
                 case "return": {
                     if (this.cfg.Generic.returnTemplate.trim().length !== 0 && this.func.type !== null) {
                         const returnParams = this.generateReturnParams();
-                        // tslint:disable-next-line:max-line-length
-                        this.generateFromTemplate(lines, this.cfg.typeTemplateReplace, this.cfg.Generic.returnTemplate, returnParams);
+                        this.generateFromTemplate(
+                            lines,
+                            this.cfg.typeTemplateReplace,
+                            this.cfg.Generic.returnTemplate,
+                            returnParams
+                        );
                     }
+                    break;
+                }
+                case "custom": {
+                    lines.push(...this.cfg.Generic.customTags);
                     break;
                 }
                 default: {

--- a/src/test/CppTests/Config.test.ts
+++ b/src/test/CppTests/Config.test.ts
@@ -219,4 +219,12 @@ suite("C++ - Configuration Tests", () => {
         assert.equal("/**\n * @brief \n * \n * @param networkstatus \n */", result);
     });
 
+    test("Custom tag", () => {
+        testSetup.cfg = new Config();
+        testSetup.cfg.Generic.order = ["custom"];
+        testSetup.cfg.Generic.customTags = ["@note"];
+        const result = testSetup.SetLine("void foo();").GetResult();
+        assert.equal("/**\n * @note\n */", result);
+    });
+
 });


### PR DESCRIPTION
# Feature

- [x] Description of what's added

- [x] Added unit test

Implements #169 

You can now specify customs tags that will be added to each comment.