### PR TITLE
Add env-var to replace env var in template strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 - Support for arbitrary tags (#169)
 
+- Replace environment variables in templated strings. If no environment variable can be found the name of the variable will be inserted (#110)
+
 ### Fix
 
 - Incorrect parameter name of template (#170)

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2017-2019 Christoph Schlosser
+Copyright (c) 2017-2020 Christoph Schlosser
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,9 +31,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "12.7.11",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.7.11.tgz",
-      "integrity": "sha512-Otxmr2rrZLKRYIybtdG/sgeO+tHY20GxeDjcGmUnmmlCWyEnv2a2x1ZXBo3BTec4OiTXMQCiazB8NMBf0iRlFw==",
+      "version": "12.7.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.7.1.tgz",
+      "integrity": "sha512-aK9jxMypeSrhiYofWWBf/T7O+KwaiAHzM4sveCdWPn71lzUSMimRnKzhXDKfKwV1kWoBo2P1aGgaIYGLf9/ljw==",
       "dev": true
     },
     "abbrev": {
@@ -405,6 +405,14 @@
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
       "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
       "dev": true
+    },
+    "env-var": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/env-var/-/env-var-4.1.0.tgz",
+      "integrity": "sha512-nPHfStlNHmQsxCmLe2Bjx+MARZ2/03/JkNpnDNSCW2uE/F1a59zePBf9Opj7Gp2d6EXowvYTl9nlL1V7ycVaIQ==",
+      "requires": {
+        "is-url": "~1.2.2"
+      }
     },
     "es-abstract": {
       "version": "1.15.0",
@@ -811,6 +819,11 @@
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
       "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
       "dev": true
+    },
+    "is-url": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/is-url/-/is-url-1.2.4.tgz",
+      "integrity": "sha512-ITvGim8FhRiYe4IQ5uHSkj7pVaPDrCTkNd3yq3cV7iZAcJdHTUMPMEHcqSOy9xZ9qFenQCvi+2wjH9a1nXqHww=="
     },
     "is-wsl": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -224,8 +224,7 @@
             "array",
             "string"
           ],
-          "default": [
-          ]
+          "default": []
         },
         "doxdocgen.generic.filteredKeywords": {
           "description": "Array of keywords that should be removed from the input prior to parsing.",
@@ -259,6 +258,7 @@
     "test": "npm run compile && node ./node_modules/vscode/bin/test"
   },
   "dependencies": {
+    "env-var": "^4.1.0",
     "moment": "^2.20.1",
     "opn": "^5.2.0"
   },

--- a/src/Lang/Cpp/CppDocGen.ts
+++ b/src/Lang/Cpp/CppDocGen.ts
@@ -1,4 +1,4 @@
-import * as env from 'env-var';
+import * as env from "env-var";
 import * as moment from "moment";
 import { Position, Range, Selection, TextEditor } from "vscode";
 import { IDocGen } from "../../Common/IDocGen";
@@ -480,7 +480,7 @@ export class CppDocGen implements IDocGen {
                     break;
                 }
                 case "custom": {
-                    this.cfg.Generic.customTags.forEach(element => {
+                    this.cfg.Generic.customTags.forEach((element) => {
                         lines.push(this.getEnvVars(element));
                     });
                     break;

--- a/src/Lang/Cpp/CppDocGen.ts
+++ b/src/Lang/Cpp/CppDocGen.ts
@@ -148,7 +148,8 @@ export class CppDocGen implements IDocGen {
         let replacement = replace;
         const regex = /\$\{env\:([\w|\d|_]+)\}/m;
         let match: RegExpExecArray;
-        
+
+        // tslint:disable-next-line:no-conditional-assignment
         while ((match = regex.exec(replacement)) !== null) {
             if (match.index === regex.lastIndex) {
                 regex.lastIndex++;
@@ -474,14 +475,14 @@ export class CppDocGen implements IDocGen {
                             lines,
                             this.cfg.typeTemplateReplace,
                             this.cfg.Generic.returnTemplate,
-                            returnParams
+                            returnParams,
                         );
                     }
                     break;
                 }
                 case "custom": {
-                    this.cfg.Generic.customTags.forEach((element) => {
-                        lines.push(this.getEnvVars(element));
+                    this.cfg.Generic.customTags.forEach((elem) => {
+                        lines.push(this.getEnvVars(elem));
                     });
                     break;
                 }

--- a/src/test/CppTests/Config.test.ts
+++ b/src/test/CppTests/Config.test.ts
@@ -232,14 +232,14 @@ suite("C++ - Configuration Tests", () => {
         testSetup.cfg.Generic.order = ["custom"];
         if (process.platform === "win32") {
             testSetup.cfg.Generic.customTags = ["@author ${env:USERNAME}"];
-            let result = testSetup.SetLine("void foo();").GetResult();
+            const res = testSetup.SetLine("void foo();").GetResult();
             // USERNAME env var is different for everybody
-            assert.notEqual("/**\n * @author USERNAME\n */", result);
+            assert.notEqual("/**\n * @author USERNAME\n */", res);
         } else {
             testSetup.cfg.Generic.customTags = ["@author ${env:USER}"];
-            let result = testSetup.SetLine("void foo();").GetResult();
+            const res = testSetup.SetLine("void foo();").GetResult();
             // USER env var is different for everybody
-            assert.notEqual("/**\n * @author USER\n */", result);
+            assert.notEqual("/**\n * @author USER\n */", res);
         }
 
         testSetup.cfg.Generic.customTags = ["@author ${env:MY_VARIABLE}"];

--- a/src/test/CppTests/Config.test.ts
+++ b/src/test/CppTests/Config.test.ts
@@ -227,4 +227,17 @@ suite("C++ - Configuration Tests", () => {
         assert.equal("/**\n * @note\n */", result);
     });
 
+    test("Env variable", () => {
+        testSetup.cfg = new Config();
+        testSetup.cfg.Generic.order = ["custom"];
+        testSetup.cfg.Generic.customTags = ["@author ${env:USER}"];
+        let result = testSetup.SetLine("void foo();").GetResult();
+        // USER env var is different for everybody
+        assert.notEqual("/**\n * @author USER\n */", result);
+
+        testSetup.cfg.Generic.customTags = ["@author ${env:MY_VARIABLE}"];
+        result = testSetup.SetLine("void foo();").GetResult();
+        assert.equal("/**\n * @author MY_VARIABLE\n */", result);
+    });
+
 });

--- a/src/test/CppTests/Config.test.ts
+++ b/src/test/CppTests/Config.test.ts
@@ -230,13 +230,20 @@ suite("C++ - Configuration Tests", () => {
     test("Env variable", () => {
         testSetup.cfg = new Config();
         testSetup.cfg.Generic.order = ["custom"];
-        testSetup.cfg.Generic.customTags = ["@author ${env:USER}"];
-        let result = testSetup.SetLine("void foo();").GetResult();
-        // USER env var is different for everybody
-        assert.notEqual("/**\n * @author USER\n */", result);
+        if (process.platform === "win32") {
+            testSetup.cfg.Generic.customTags = ["@author ${env:USERNAME}"];
+            let result = testSetup.SetLine("void foo();").GetResult();
+            // USERNAME env var is different for everybody
+            assert.notEqual("/**\n * @author USERNAME\n */", result);
+        } else {
+            testSetup.cfg.Generic.customTags = ["@author ${env:USER}"];
+            let result = testSetup.SetLine("void foo();").GetResult();
+            // USER env var is different for everybody
+            assert.notEqual("/**\n * @author USER\n */", result);
+        }
 
         testSetup.cfg.Generic.customTags = ["@author ${env:MY_VARIABLE}"];
-        result = testSetup.SetLine("void foo();").GetResult();
+        const result = testSetup.SetLine("void foo();").GetResult();
         assert.equal("/**\n * @author MY_VARIABLE\n */", result);
     });
 


### PR DESCRIPTION
# Feature

- [x] Description of what's added

- [x] Added unit test

Fixes #110 

Add possibility to get the content of env vars in templated strings.

If not env var can be found the name of the env var will be inserted.