### PR TITLE
Replaced assert.equal() calls by assert.strictEqual() calls

### DIFF
--- a/src/test/CppTests/Attributes.test.ts
+++ b/src/test/CppTests/Attributes.test.ts
@@ -18,50 +18,50 @@ suite("C++ - Attributes Tests", () => {
     // Tests
     test("Attributes on parameter", () => {
         const result = testSetup.SetLine("int foo([[maybe_unused]] int a, [[maybe_unused]]double& b);").GetResult();
-        assert.equal("/**\n * @brief \n * \n * @param a \n * @param b \n * @return int \n */", result);
+        assert.strictEqual("/**\n * @brief \n * \n * @param a \n * @param b \n * @return int \n */", result);
     });
 
     test("Attributes on function", () => {
         const result = testSetup.SetLine("[[nodiscard]] int foo(int a, double& b);").GetResult();
-        assert.equal("/**\n * @brief \n * \n * @param a \n * @param b \n * @return int \n */", result);
+        assert.strictEqual("/**\n * @brief \n * \n * @param a \n * @param b \n * @return int \n */", result);
     });
 
     test("Multiple attributes on parameter", () => {
         const result = testSetup.SetLine("int foo([[maybe_unused]] [[carries_dependency]]"
             + " int a, double& b);").GetResult();
-        assert.equal("/**\n * @brief \n * \n * @param a \n * @param b \n * @return int \n */", result);
+        assert.strictEqual("/**\n * @brief \n * \n * @param a \n * @param b \n * @return int \n */", result);
     });
 
     test("Multiple attributes on function", () => {
         const result = testSetup.SetLine("[[nodiscard]][[deprecated(\"old\")]] int foo(int a, double& b);").GetResult();
-        assert.equal("/**\n * @brief \n * \n * @param a \n * @param b \n * @return int \n */", result);
+        assert.strictEqual("/**\n * @brief \n * \n * @param a \n * @param b \n * @return int \n */", result);
     });
 
     test("Specifier and attribute on class", () => {
         const result = testSetup.SetLine("class [[nodiscard]] alignas(8) Matrix {").GetResult();
-        assert.equal("/**\n * @brief \n * \n */", result);
+        assert.strictEqual("/**\n * @brief \n * \n */", result);
     });
 
     test("Specifier and attribute on struct", () => {
         const result = testSetup.SetLine("struct [[nodiscard]] alignas(8) Matrix {").GetResult();
-        assert.equal("/**\n * @brief \n * \n */", result);
+        assert.strictEqual("/**\n * @brief \n * \n */", result);
     });
 
     test("Noexcept on function", () => {
         let result = testSetup.SetLine("constexpr int foo(int a, double& b) noexcept(true);").GetResult();
-        assert.equal("/**\n * @brief \n * \n * @param a \n * @param b \n * @return constexpr int \n */", result);
+        assert.strictEqual("/**\n * @brief \n * \n * @param a \n * @param b \n * @return constexpr int \n */", result);
 
         result = testSetup.SetLine("constexpr int foo(int a, double& b) noexcept;").GetResult();
-        assert.equal("/**\n * @brief \n * \n * @param a \n * @param b \n * @return constexpr int \n */", result);
+        assert.strictEqual("/**\n * @brief \n * \n * @param a \n * @param b \n * @return constexpr int \n */", result);
     });
 
     test("Throw on function", () => {
         const result = testSetup.SetLine("constexpr int foo(int a, double& b) throw(std::except);").GetResult();
-        assert.equal("/**\n * @brief \n * \n * @param a \n * @param b \n * @return constexpr int \n */", result);
+        assert.strictEqual("/**\n * @brief \n * \n * @param a \n * @param b \n * @return constexpr int \n */", result);
     });
 
     test("Newline in function", () => {
         const result = testSetup.SetLines(["static void ResetActionState( BOOL sendNAK )", "{"]).GetResult();
-        assert.equal("/**\n * @brief \n * \n * @param sendNAK \n */", result);
+        assert.strictEqual("/**\n * @brief \n * \n * @param sendNAK \n */", result);
     });
 });

--- a/src/test/CppTests/Con-AndDestructor.test.ts
+++ b/src/test/CppTests/Con-AndDestructor.test.ts
@@ -20,46 +20,46 @@ suite("C++ - Con- and Destructor Tests", () => {
     // Tests
     test("Normal Constructor", () => {
         const result = testSetup.SetLine("Foo(int a);").GetResult();
-        assert.equal("/**\n * @brief \n * \n * @param a \n */", result);
+        assert.strictEqual("/**\n * @brief \n * \n * @param a \n */", result);
     });
 
     test("Constructor with initializer list", () => {
         const result = testSetup.SetLine("Foo(int a) : m_a(a) {").GetResult();
-        assert.equal("/**\n * @brief \n * \n * @param a \n */", result);
+        assert.strictEqual("/**\n * @brief \n * \n * @param a \n */", result);
     });
 
     test("Explicit Constructor", () => {
         const result = testSetup.SetLine("explicit Foo(int a);").GetResult();
-        assert.equal("/**\n * @brief \n * \n * @param a \n */", result);
+        assert.strictEqual("/**\n * @brief \n * \n * @param a \n */", result);
     });
 
     test("Deleted Constructor", () => {
         const result = testSetup.SetLine("Foo(int a) = delete;").GetResult();
-        assert.equal("/**\n * @brief \n * \n * @param a \n */", result);
+        assert.strictEqual("/**\n * @brief \n * \n * @param a \n */", result);
     });
 
     test("Default Constructor", () => {
         const result = testSetup.SetLine("Foo() = default;").GetResult();
-        assert.equal("/**\n * @brief \n * \n */", result);
+        assert.strictEqual("/**\n * @brief \n * \n */", result);
     });
 
     test("Destructor", () => {
         const result = testSetup.SetLine("~Foo();").GetResult();
-        assert.equal("/**\n * @brief \n * \n */", result);
+        assert.strictEqual("/**\n * @brief \n * \n */", result);
     });
 
     test("Virtual Destructor", () => {
         const result = testSetup.SetLine("virtual ~Foo();").GetResult();
-        assert.equal("/**\n * @brief \n * \n */", result);
+        assert.strictEqual("/**\n * @brief \n * \n */", result);
     });
 
     test("Deleted Destructor", () => {
         const result = testSetup.SetLine("virtual ~Foo() = 0;").GetResult();
-        assert.equal("/**\n * @brief \n * \n */", result);
+        assert.strictEqual("/**\n * @brief \n * \n */", result);
     });
 
     test("Default Destructor", () => {
         const result = testSetup.SetLine("~Foo() = default;").GetResult();
-        assert.equal("/**\n * @brief \n * \n */", result);
+        assert.strictEqual("/**\n * @brief \n * \n */", result);
     });
 });

--- a/src/test/CppTests/Config.test.ts
+++ b/src/test/CppTests/Config.test.ts
@@ -21,7 +21,7 @@ suite("C++ - Configuration Tests", () => {
     test("Default config", () => {
         testSetup.cfg = new Config();
         const result = testSetup.SetLine("template<typename T> bool foo(T a);").GetResult();
-        assert.equal("/**\n * @brief \n * \n * @tparam T \n * @param a \n * "
+        assert.strictEqual("/**\n * @brief \n * \n * @tparam T \n * @param a \n * "
             + "@return true \n * @return false \n */", result);
     });
 
@@ -29,7 +29,7 @@ suite("C++ - Configuration Tests", () => {
         testSetup.cfg = new Config();
         testSetup.cfg.Generic.order = ["brief", "param", "tparam", "return"];
         const result = testSetup.SetLine("template<typename T> bool foo(T a);").GetResult();
-        assert.equal("/**\n * @brief \n * @param a \n * @tparam T \n * "
+        assert.strictEqual("/**\n * @brief \n * @param a \n * @tparam T \n * "
             + "@return true \n * @return false \n */", result);
     });
 
@@ -37,7 +37,7 @@ suite("C++ - Configuration Tests", () => {
         testSetup.cfg = new Config();
         testSetup.cfg.Generic.order = ["breif"];
         const result = testSetup.SetLine("template<typename T> bool foo(T a);").GetResult();
-        assert.equal("/**\n */", result);
+        assert.strictEqual("/**\n */", result);
     });
 
     test("Modified template", () => {
@@ -52,7 +52,7 @@ suite("C++ - Configuration Tests", () => {
         testSetup.cfg.Generic.returnTemplate = "\\return {type} ";
 
         const result = testSetup.SetLine("template<typename T> bool foo(T a);").GetResult();
-        assert.equal("/// \\brief \n/// \n/// \\tparam T \n/// \\param a \n"
+        assert.strictEqual("/// \\brief \n/// \n/// \\tparam T \n/// \\param a \n"
             + "/// \\return true \n/// \\return false ", result);
 
     });
@@ -61,7 +61,7 @@ suite("C++ - Configuration Tests", () => {
         testSetup.cfg = new Config();
         testSetup.cfg.Generic.boolReturnsTrueFalse = false;
         const result = testSetup.SetLine("template<typename T> bool foo(T a);").GetResult();
-        assert.equal("/**\n * @brief \n * \n * @tparam T \n * @param a \n"
+        assert.strictEqual("/**\n * @brief \n * \n * @tparam T \n * @param a \n"
             + " * @return bool \n */", result);
     });
 
@@ -70,7 +70,7 @@ suite("C++ - Configuration Tests", () => {
         testSetup.cfg.Generic.includeTypeAtReturn = false;
 
         const result = testSetup.SetLine("template<typename T> bool foo(T a);").GetResult();
-        assert.equal("/**\n * @brief \n * \n * @tparam T \n * @param a \n"
+        assert.strictEqual("/**\n * @brief \n * \n * @tparam T \n * @param a \n"
             + " * @return  \n */", result);
     });
 
@@ -80,18 +80,18 @@ suite("C++ - Configuration Tests", () => {
 
         const result = testSetup.SetLine("template<typename T> bool foo(T a);").GetResult();
         testSetup.cfg.Generic.order = ["brief", "empty", "tparam", "param", "return"]; // reset to default
-        assert.equal("/**\n * @brief \n * @tparam T \n * \n * @param a \n * \n"
+        assert.strictEqual("/**\n * @brief \n * @tparam T \n * \n * @param a \n * \n"
             + " * @return true \n * @return false \n */", result);
     });
 
     test("Indentation test", () => {
         testSetup.cfg = new Config();
         let result = testSetup.SetLine("\ttemplate<typename T> bool foo(T a);").GetResult();
-        assert.equal("/**\n\t * @brief \n\t * \n\t * @tparam T \n\t * @param a \n\t * "
+        assert.strictEqual("/**\n\t * @brief \n\t * \n\t * @tparam T \n\t * @param a \n\t * "
             + "@return true \n\t * @return false \n\t */", result);
 
         result = testSetup.SetLine("          template<typename T> bool foo(T a);").GetResult();
-        assert.equal("/**\n           * @brief \n           * \n           * @tparam T "
+        assert.strictEqual("/**\n           * @brief \n           * \n           * @tparam T "
             + "\n           * @param a \n           * "
             + "@return true \n           * @return false \n           */", result);
     });
@@ -100,12 +100,12 @@ suite("C++ - Configuration Tests", () => {
         testSetup.cfg = new Config();
         testSetup.cfg.Generic.linesToGet = 2;
         const positiveResult = testSetup.SetLines(["template<typename T> bool \n", "foo(T a);"]).GetResult();
-        assert.equal("/**\n * @brief \n * \n * @tparam T \n * @param a \n * "
+        assert.strictEqual("/**\n * @brief \n * \n * @tparam T \n * @param a \n * "
             + "@return true \n * @return false \n */", positiveResult);
         testSetup.cfg.Generic.linesToGet = 0;
         testSetup.firstLine = 1;
         const negativeResult = testSetup.SetLines(["template<typename T> bool \n", "foo(T a);"]).GetResult();
-        assert.equal("/**\n * @brief \n * \n */", negativeResult);
+        assert.strictEqual("/**\n * @brief \n * \n */", negativeResult);
     });
 
     test("File description order test", () => {
@@ -113,50 +113,50 @@ suite("C++ - Configuration Tests", () => {
         testSetup.firstLine = 0;
         testSetup.cfg.File.fileOrder = ["brief", "author", "date", "file"];
         const result = testSetup.SetLine("").GetResult();
-        assert.equal("/**\n * @brief \n * @author your name (you@domain.com)\n" +
+        assert.strictEqual("/**\n * @brief \n * @author your name (you@domain.com)\n" +
             " * @date " + moment().format("YYYY-MM-DD") + "\n * @file MockDocument.h\n */", result);
     });
 
     test("Custom smart text Ctor", () => {
         testSetup.cfg.Cpp.ctorText = "Test {name}";
         const result = testSetup.SetLine("Foo();").GetResult();
-        assert.equal("/**\n * @brief Test Foo\n * \n */", result);
+        assert.strictEqual("/**\n * @brief Test Foo\n * \n */", result);
     });
 
     test("Custom smart text Dtor", () => {
         testSetup.cfg.Cpp.dtorText = "Test {name}";
         const result = testSetup.SetLine("~Foo();").GetResult();
-        assert.equal("/**\n * @brief Test Foo\n * \n */", result);
+        assert.strictEqual("/**\n * @brief Test Foo\n * \n */", result);
     });
 
     test("Custom smart text getter", () => {
         testSetup.cfg.C.getterText = "Test {name}";
         const result = testSetup.SetLine("int getFoo();").GetResult();
-        assert.equal("/**\n * @brief Test Foo\n * \n * @return int \n */", result);
+        assert.strictEqual("/**\n * @brief Test Foo\n * \n * @return int \n */", result);
     });
 
     test("Custom smart text setter", () => {
         testSetup.cfg.C.setterText = "Test {name}";
         const result = testSetup.SetLine("void setFoo(int foo);").GetResult();
-        assert.equal("/**\n * @brief Test Foo\n * \n * @param foo \n */", result);
+        assert.strictEqual("/**\n * @brief Test Foo\n * \n * @param foo \n */", result);
     });
 
     test("Custom smart text factory method", () => {
         testSetup.cfg.C.factoryMethodText = "Test {name}";
         const result = testSetup.SetLine("int createFoo();").GetResult();
-        assert.equal("/**\n * @brief Test Foo\n * \n * @return int \n */", result);
+        assert.strictEqual("/**\n * @brief Test Foo\n * \n * @return int \n */", result);
     });
 
     test("Don't split casing for smart text", () => {
         testSetup.cfg.C.factoryMethodText = "Test {name}";
         testSetup.cfg.Generic.splitCasingSmartText = false;
         const result = testSetup.SetLine("int createFooObject();").GetResult();
-        assert.equal("/**\n * @brief Test FooObject\n * \n * @return int \n */", result);
+        assert.strictEqual("/**\n * @brief Test FooObject\n * \n * @return int \n */", result);
     });
 
     test("Remove inserted '*/' from line", () => {
         const result = testSetup.SetLines(["*/", "int foo();"]).GetResult();
-        assert.equal("/**\n * @brief \n * \n * @return int \n */", result);
+        assert.strictEqual("/**\n * @brief \n * \n * @return int \n */", result);
     });
 
     test("Single alignment", () => {
@@ -167,7 +167,7 @@ suite("C++ - Configuration Tests", () => {
 
         const result = testSetup.SetLines(["template<typename T>", "int foo(std::string bar, T foobar);"]).GetResult();
         // tslint:disable-next-line:max-line-length
-        assert.equal("/**\n * @brief    Brief\n * \n * @tparam   T\n * @param    bar\n * @param    foobar\n * @return   int\n */", result);
+        assert.strictEqual("/**\n * @brief    Brief\n * \n * @tparam   T\n * @param    bar\n * @param    foobar\n * @return   int\n */", result);
     });
 
     test("Multi alignment", () => {
@@ -198,7 +198,7 @@ suite("C++ - Configuration Tests", () => {
         testSetup.cfg.Generic.returnTemplate = "<returns>\n</returns>";
         const result = testSetup.SetLine("    int foo(bool a);").GetResult();
         // tslint:disable:no-trailing-whitespace
-        assert.equal(
+        assert.strictEqual(
             result, `/// <summary>
     /// 
     /// </summary>
@@ -216,7 +216,7 @@ suite("C++ - Configuration Tests", () => {
         testSetup.cfg.Generic.filteredKeywords = ["MOCKABLE"];
         // tslint:disable-next-line:max-line-length
         const result = testSetup.SetLine("MOCKABLE void processNetworkStatusReset( const common_n::NetworkCommands_s *networkstatus );").GetResult();
-        assert.equal("/**\n * @brief \n * \n * @param networkstatus \n */", result);
+        assert.strictEqual("/**\n * @brief \n * \n * @param networkstatus \n */", result);
     });
 
     test("Custom tag", () => {
@@ -224,7 +224,7 @@ suite("C++ - Configuration Tests", () => {
         testSetup.cfg.Generic.order = ["custom"];
         testSetup.cfg.Generic.customTags = ["@note"];
         const result = testSetup.SetLine("void foo();").GetResult();
-        assert.equal("/**\n * @note\n */", result);
+        assert.strictEqual("/**\n * @note\n */", result);
     });
 
     test("Env variable", () => {
@@ -234,17 +234,17 @@ suite("C++ - Configuration Tests", () => {
             testSetup.cfg.Generic.customTags = ["@author ${env:USERNAME}"];
             const res = testSetup.SetLine("void foo();").GetResult();
             // USERNAME env var is different for everybody
-            assert.notEqual("/**\n * @author USERNAME\n */", res);
+            assert.notStrictEqual("/**\n * @author USERNAME\n */", res);
         } else {
             testSetup.cfg.Generic.customTags = ["@author ${env:USER}"];
             const res = testSetup.SetLine("void foo();").GetResult();
             // USER env var is different for everybody
-            assert.notEqual("/**\n * @author USER\n */", res);
+            assert.notStrictEqual("/**\n * @author USER\n */", res);
         }
 
         testSetup.cfg.Generic.customTags = ["@author ${env:MY_VARIABLE}"];
         const result = testSetup.SetLine("void foo();").GetResult();
-        assert.equal("/**\n * @author MY_VARIABLE\n */", result);
+        assert.strictEqual("/**\n * @author MY_VARIABLE\n */", result);
     });
 
 });

--- a/src/test/CppTests/FileDescription.test.ts
+++ b/src/test/CppTests/FileDescription.test.ts
@@ -22,19 +22,19 @@ suite("File Description Tests", () => {
     // Tests
     test("#include on next line", () => {
         const result = testSetup.SetLine("#include <iostream>").GetResult();
-        assert.equal("/**\n * @brief \n * \n * @file MockDocument.h\n * @author your name (you@domain.com)\n" +
+        assert.strictEqual("/**\n * @brief \n * \n * @file MockDocument.h\n * @author your name (you@domain.com)\n" +
             " * @date " + date + "\n */", result);
     });
 
     test("#pragma on next line", () => {
         const result = testSetup.SetLine("#pragma Foo").GetResult();
-        assert.equal("/**\n * @brief \n * \n * @file MockDocument.h\n * @author your name (you@domain.com)\n" +
+        assert.strictEqual("/**\n * @brief \n * \n * @file MockDocument.h\n * @author your name (you@domain.com)\n" +
             " * @date " + date + "\n */", result);
     });
 
     test("On first line of document", () => {
         const result = testSetup.SetLine("").GetResult();
-        assert.equal("/**\n * @brief \n * \n * @file MockDocument.h\n * @author your name (you@domain.com)\n" +
+        assert.strictEqual("/**\n * @brief \n * \n * @file MockDocument.h\n * @author your name (you@domain.com)\n" +
             " * @date " + date + "\n */", result);
     });
 
@@ -47,32 +47,32 @@ suite("File Description Tests", () => {
             "   int i;",
             "};",
             ], false).GetResult();
-        assert.equal("/**\n * @brief \n * \n * @file MockDocument.h\n * @author your name (you@domain.com)\n" +
+        assert.strictEqual("/**\n * @brief \n * \n * @file MockDocument.h\n * @author your name (you@domain.com)\n" +
             " * @date " + date + "\n */", result);
     });
 
     test("Don't generate non existing commands", () => {
         testSetup.cfg.File.fileOrder = ["dates"];
         const result = testSetup.SetLine("").GetResult();
-        assert.equal("/**\n */", result);
+        assert.strictEqual("/**\n */", result);
     });
 
     test("version block", () => {
         testSetup.cfg.File.fileOrder = ["version"];
         const result = testSetup.SetLine("").GetResult();
-        assert.equal("/**\n * @version 0.1\n */", result);
+        assert.strictEqual("/**\n * @version 0.1\n */", result);
     });
 
     test("Copyright block", () => {
         testSetup.cfg.File.fileOrder = ["copyright"];
         const result = testSetup.SetLine("").GetResult();
-        assert.equal("/**\n * @copyright Copyright (c) " + year + "\n */", result);
+        assert.strictEqual("/**\n * @copyright Copyright (c) " + year + "\n */", result);
     });
 
     test("version block", () => {
         testSetup.cfg.File.fileOrder = ["version"];
         const result = testSetup.SetLine("").GetResult();
-        assert.equal("/**\n * @version 0.1\n */", result);
+        assert.strictEqual("/**\n * @version 0.1\n */", result);
     });
 
     test("custom block", () => {
@@ -80,7 +80,7 @@ suite("File Description Tests", () => {
         testSetup.cfg.File.customTag = ["First Line", "{year} Year Line", "{date} Date Line",
                                         "{author} Author Line", "{email} Email Line"];
         const result = testSetup.SetLine("").GetResult();
-        assert.equal("/**\n * First Line\n * " + year + " Year Line\n * " + date + " Date Line\n" +
+        assert.strictEqual("/**\n * First Line\n * " + year + " Year Line\n * " + date + " Date Line\n" +
             " * your name Author Line\n * you@domain.com Email Line\n */", result);
     });
 });

--- a/src/test/CppTests/FunctionPointer.test.ts
+++ b/src/test/CppTests/FunctionPointer.test.ts
@@ -18,35 +18,35 @@ suite("C++ - Function pointer Tests", () => {
     // Tests
     test("Function pointer return", () => {
         const result = testSetup.SetLine("int (*idputs(int a, int b))(char *);").GetResult();
-        assert.equal("/**\n * @brief \n * \n * @param a \n * @param b \n * @return int(*)(char*) \n */", result);
+        assert.strictEqual("/**\n * @brief \n * \n * @param a \n * @param b \n * @return int(*)(char*) \n */", result);
     });
 
     test("Nested function pointer return", () => {
         const result = testSetup.SetLine("int (*(*(*foo(int a, int b))(int))(double))(float);").GetResult();
-        assert.equal("/**\n * @brief \n * \n * @param a \n * @param b \n"
+        assert.strictEqual("/**\n * @brief \n * \n * @param a \n * @param b \n"
             + " * @return int(*(*(*)(int))(double))(float) \n */", result);
     });
 
     test("Function pointer parameter", () => {
         const result = testSetup.SetLine("int foo(int (*puts)(const char *));").GetResult();
-        assert.equal("/**\n * @brief \n * \n * @param puts \n * @return int \n */", result);
+        assert.strictEqual("/**\n * @brief \n * \n * @param puts \n * @return int \n */", result);
     });
 
     test("Struct function pointer return with struct FP parameters and keywords", () => {
         const result = testSetup.SetLine("const struct foo (*idputs(int (*puts)(const char *), const"
             + " struct test(*str)(int *, const struct test(*str2))))(const char *);").GetResult();
 
-        assert.equal("/**\n * @brief \n * \n * @param puts \n * @param str "
+        assert.strictEqual("/**\n * @brief \n * \n * @param puts \n * @param str "
             + "\n * @return const struct foo(*)(const char*) \n */", result);
     });
 
     test("Memberpointer in function pointer", () => {
         const result = testSetup.SetLine("void foo(void (SomeClass::* func)());").GetResult();
-        assert.equal("/**\n * @brief \n * \n * @param func \n */", result);
+        assert.strictEqual("/**\n * @brief \n * \n * @param func \n */", result);
     });
 
     test("Arraypointer", () => {
         const result = testSetup.SetLine("void some_function(int (*table)[]);").GetResult();
-        assert.equal("/**\n * @brief \n * \n * @param table \n */", result);
+        assert.strictEqual("/**\n * @brief \n * \n * @param table \n */", result);
     });
 });

--- a/src/test/CppTests/Operators.test.ts
+++ b/src/test/CppTests/Operators.test.ts
@@ -18,283 +18,283 @@ suite("C++ - Operators Tests", () => {
     // Tests
     test("+ operator", () => {
         const result = testSetup.SetLine("T operator +(const T& lhs, const T2& rhs);").GetResult();
-        assert.equal("/**\n * @brief \n * \n * @param lhs \n * @param rhs \n * @return T \n */", result);
+        assert.strictEqual("/**\n * @brief \n * \n * @param lhs \n * @param rhs \n * @return T \n */", result);
     });
 
     test("- operator", () => {
         const result = testSetup.SetLine("T operator- (const T& lhs, const T2& rhs);").GetResult();
-        assert.equal("/**\n * @brief \n * \n * @param lhs \n * @param rhs \n * @return T \n */", result);
+        assert.strictEqual("/**\n * @brief \n * \n * @param lhs \n * @param rhs \n * @return T \n */", result);
     });
 
     test("* operator with params", () => {
         const result = testSetup.SetLine("T operator*(const T& lhs, const T2& rhs);").GetResult();
-        assert.equal("/**\n * @brief \n * \n * @param lhs \n * @param rhs \n * @return T \n */", result);
+        assert.strictEqual("/**\n * @brief \n * \n * @param lhs \n * @param rhs \n * @return T \n */", result);
     });
 
     test("/ operator", () => {
         const result = testSetup.SetLine("T operator/(const T& lhs, const T2& rhs);").GetResult();
-        assert.equal("/**\n * @brief \n * \n * @param lhs \n * @param rhs \n * @return T \n */", result);
+        assert.strictEqual("/**\n * @brief \n * \n * @param lhs \n * @param rhs \n * @return T \n */", result);
     });
 
     test("% operator", () => {
         const result = testSetup.SetLine("T operator%(const T& lhs, const T2& rhs);").GetResult();
-        assert.equal("/**\n * @brief \n * \n * @param lhs \n * @param rhs \n * @return T \n */", result);
+        assert.strictEqual("/**\n * @brief \n * \n * @param lhs \n * @param rhs \n * @return T \n */", result);
     });
 
     test("^ operator", () => {
         const result = testSetup.SetLine("T operator^(const T& lhs, const T2& rhs);").GetResult();
-        assert.equal("/**\n * @brief \n * \n * @param lhs \n * @param rhs \n * @return T \n */", result);
+        assert.strictEqual("/**\n * @brief \n * \n * @param lhs \n * @param rhs \n * @return T \n */", result);
     });
 
     test("& operator with params", () => {
         const result = testSetup.SetLine("T operator&(const T& lhs, const T2& rhs);").GetResult();
-        assert.equal("/**\n * @brief \n * \n * @param lhs \n * @param rhs \n * @return T \n */", result);
+        assert.strictEqual("/**\n * @brief \n * \n * @param lhs \n * @param rhs \n * @return T \n */", result);
     });
 
     test("| operator", () => {
         const result = testSetup.SetLine("T operator|(const T& lhs, const T2& rhs);").GetResult();
-        assert.equal("/**\n * @brief \n * \n * @param lhs \n * @param rhs \n * @return T \n */", result);
+        assert.strictEqual("/**\n * @brief \n * \n * @param lhs \n * @param rhs \n * @return T \n */", result);
     });
 
     test("~ operator", () => {
         const result = testSetup.SetLine("T operator~(const T& t);").GetResult();
-        assert.equal("/**\n * @brief \n * \n * @param t \n * @return T \n */", result);
+        assert.strictEqual("/**\n * @brief \n * \n * @param t \n * @return T \n */", result);
     });
 
     test("<< operator", () => {
         const result = testSetup.SetLine("T operator<<(const T& lhs, const T2& rhs);").GetResult();
-        assert.equal("/**\n * @brief \n * \n * @param lhs \n * @param rhs \n * @return T \n */", result);
+        assert.strictEqual("/**\n * @brief \n * \n * @param lhs \n * @param rhs \n * @return T \n */", result);
     });
 
     test(">> operator", () => {
         const result = testSetup.SetLine("T operator>>(const T& lhs, const T2& rhs);").GetResult();
-        assert.equal("/**\n * @brief \n * \n * @param lhs \n * @param rhs \n * @return T \n */", result);
+        assert.strictEqual("/**\n * @brief \n * \n * @param lhs \n * @param rhs \n * @return T \n */", result);
     });
 
     test("! operator", () => {
         const result = testSetup.SetLine("bool operator!(const T& t);").GetResult();
-        assert.equal("/**\n * @brief \n * \n * @param t \n * @return true \n * @return false \n */", result);
+        assert.strictEqual("/**\n * @brief \n * \n * @param t \n * @return true \n * @return false \n */", result);
     });
 
     test("&& operator", () => {
         const result = testSetup.SetLine("bool operator&&(const T& lhs, const T2& rhs);").GetResult();
-        assert.equal("/**\n * @brief \n * \n * @param lhs \n * @param rhs \n * @return true \n"
+        assert.strictEqual("/**\n * @brief \n * \n * @param lhs \n * @param rhs \n * @return true \n"
             + " * @return false \n */", result);
     });
 
     test("|| operator", () => {
         const result = testSetup.SetLine("bool operator||(const T& lhs, const T2& rhs);").GetResult();
-        assert.equal("/**\n * @brief \n * \n * @param lhs \n * @param rhs \n * @return true \n"
+        assert.strictEqual("/**\n * @brief \n * \n * @param lhs \n * @param rhs \n * @return true \n"
             + " * @return false \n */", result);
     });
 
     test("!= operator", () => {
         const result = testSetup.SetLine("bool operator!=(const T& lhs, const T2& rhs);").GetResult();
-        assert.equal("/**\n * @brief \n * \n * @param lhs \n * @param rhs \n * @return true \n"
+        assert.strictEqual("/**\n * @brief \n * \n * @param lhs \n * @param rhs \n * @return true \n"
             + " * @return false \n */", result);
     });
 
     test("== operator", () => {
         const result = testSetup.SetLine("bool operator==(const T& lhs, const T2& rhs);").GetResult();
-        assert.equal("/**\n * @brief \n * \n * @param lhs \n * @param rhs \n * @return true \n"
+        assert.strictEqual("/**\n * @brief \n * \n * @param lhs \n * @param rhs \n * @return true \n"
             + " * @return false \n */", result);
     });
 
     test("<= operator", () => {
         const result = testSetup.SetLine("bool operator<=(const T& lhs, const T2& rhs);").GetResult();
-        assert.equal("/**\n * @brief \n * \n * @param lhs \n * @param rhs \n * @return true \n"
+        assert.strictEqual("/**\n * @brief \n * \n * @param lhs \n * @param rhs \n * @return true \n"
             + " * @return false \n */", result);
     });
 
     test(">= operator", () => {
         const result = testSetup.SetLine("bool operator>=(const T& lhs, const T2& rhs);").GetResult();
-        assert.equal("/**\n * @brief \n * \n * @param lhs \n * @param rhs \n * @return true \n"
+        assert.strictEqual("/**\n * @brief \n * \n * @param lhs \n * @param rhs \n * @return true \n"
             + " * @return false \n */", result);
     });
 
     test("< operator", () => {
         const result = testSetup.SetLine("bool operator<(const T& lhs, const T2& rhs);").GetResult();
-        assert.equal("/**\n * @brief \n * \n * @param lhs \n * @param rhs \n * @return true \n"
+        assert.strictEqual("/**\n * @brief \n * \n * @param lhs \n * @param rhs \n * @return true \n"
             + " * @return false \n */", result);
     });
 
     test("> operator", () => {
         const result = testSetup.SetLine("bool operator>(const T& lhs, const T2& rhs);").GetResult();
-        assert.equal("/**\n * @brief \n * \n * @param lhs \n * @param rhs \n * @return true \n"
+        assert.strictEqual("/**\n * @brief \n * \n * @param lhs \n * @param rhs \n * @return true \n"
             + " * @return false \n */", result);
     });
 
     test("= operator", () => {
         const result = testSetup.SetLine("T& operator=(const T& t);").GetResult();
-        assert.equal("/**\n * @brief \n * \n * @param t \n * @return T& \n */", result);
+        assert.strictEqual("/**\n * @brief \n * \n * @param t \n * @return T& \n */", result);
     });
 
     test("+= operator", () => {
         const result = testSetup.SetLine("T& operator+=(const T& t);").GetResult();
-        assert.equal("/**\n * @brief \n * \n * @param t \n * @return T& \n */", result);
+        assert.strictEqual("/**\n * @brief \n * \n * @param t \n * @return T& \n */", result);
     });
 
     test("-= operator", () => {
         const result = testSetup.SetLine("T& operator-=(const T& t);").GetResult();
-        assert.equal("/**\n * @brief \n * \n * @param t \n * @return T& \n */", result);
+        assert.strictEqual("/**\n * @brief \n * \n * @param t \n * @return T& \n */", result);
     });
 
     test("*= operator", () => {
         const result = testSetup.SetLine("T& operator*=(const T& t);").GetResult();
-        assert.equal("/**\n * @brief \n * \n * @param t \n * @return T& \n */", result);
+        assert.strictEqual("/**\n * @brief \n * \n * @param t \n * @return T& \n */", result);
     });
 
     test("/= operator", () => {
         const result = testSetup.SetLine("T& operator/=(const T& t);").GetResult();
-        assert.equal("/**\n * @brief \n * \n * @param t \n * @return T& \n */", result);
+        assert.strictEqual("/**\n * @brief \n * \n * @param t \n * @return T& \n */", result);
     });
 
     test("%= operator", () => {
         const result = testSetup.SetLine("T& operator%=(const T& t);").GetResult();
-        assert.equal("/**\n * @brief \n * \n * @param t \n * @return T& \n */", result);
+        assert.strictEqual("/**\n * @brief \n * \n * @param t \n * @return T& \n */", result);
     });
 
     test("^= operator", () => {
         const result = testSetup.SetLine("T& operator^=(const T& t);").GetResult();
-        assert.equal("/**\n * @brief \n * \n * @param t \n * @return T& \n */", result);
+        assert.strictEqual("/**\n * @brief \n * \n * @param t \n * @return T& \n */", result);
     });
 
     test("&= operator", () => {
         const result = testSetup.SetLine("T& operator&=(const T& t);").GetResult();
-        assert.equal("/**\n * @brief \n * \n * @param t \n * @return T& \n */", result);
+        assert.strictEqual("/**\n * @brief \n * \n * @param t \n * @return T& \n */", result);
     });
 
     test("|= operator", () => {
         const result = testSetup.SetLine("T& operator|=(const T& t);").GetResult();
-        assert.equal("/**\n * @brief \n * \n * @param t \n * @return T& \n */", result);
+        assert.strictEqual("/**\n * @brief \n * \n * @param t \n * @return T& \n */", result);
     });
 
     test(">>= operator", () => {
         const result = testSetup.SetLine("T& operator>>=(const T& t);").GetResult();
-        assert.equal("/**\n * @brief \n * \n * @param t \n * @return T& \n */", result);
+        assert.strictEqual("/**\n * @brief \n * \n * @param t \n * @return T& \n */", result);
     });
 
     test("<<= operator", () => {
         const result = testSetup.SetLine("T& operator<<=(const T& t);").GetResult();
-        assert.equal("/**\n * @brief \n * \n * @param t \n * @return T& \n */", result);
+        assert.strictEqual("/**\n * @brief \n * \n * @param t \n * @return T& \n */", result);
     });
 
     test("prefix ++ operator", () => {
         const result = testSetup.SetLine("T& operator++();").GetResult();
-        assert.equal("/**\n * @brief \n * \n * @return T& \n */", result);
+        assert.strictEqual("/**\n * @brief \n * \n * @return T& \n */", result);
     });
 
     test("prefix -- operator", () => {
         const result = testSetup.SetLine("T& operator--();").GetResult();
-        assert.equal("/**\n * @brief \n * \n * @return T& \n */", result);
+        assert.strictEqual("/**\n * @brief \n * \n * @return T& \n */", result);
     });
 
     test("postfix ++ operator", () => {
         const result = testSetup.SetLine("T operator++(int);").GetResult();
-        assert.equal("/**\n * @brief \n * \n * @return T \n */", result);
+        assert.strictEqual("/**\n * @brief \n * \n * @return T \n */", result);
     });
 
     test("postfix -- operator", () => {
         const result = testSetup.SetLine("T operator--(int);").GetResult();
-        assert.equal("/**\n * @brief \n * \n * @return T \n */", result);
+        assert.strictEqual("/**\n * @brief \n * \n * @return T \n */", result);
     });
 
     test("() operator", () => {
         let result = testSetup.SetLine("R operator()(const T& a, const T2& b);").GetResult();
-        assert.equal("/**\n * @brief \n * \n * @param a \n * @param b \n * @return R \n */", result);
+        assert.strictEqual("/**\n * @brief \n * \n * @param a \n * @param b \n * @return R \n */", result);
 
         result = testSetup.SetLine("R operator( )(const T& a, const T2& b);").GetResult();
-        assert.equal("/**\n * @brief \n * \n * @param a \n * @param b \n * @return R \n */", result);
+        assert.strictEqual("/**\n * @brief \n * \n * @param a \n * @param b \n * @return R \n */", result);
     });
 
     test(", operator", () => {
         const result = testSetup.SetLine("T2& operator , (const T2& t);").GetResult();
-        assert.equal("/**\n * @brief \n * \n * @param t \n * @return T2& \n */", result);
+        assert.strictEqual("/**\n * @brief \n * \n * @param t \n * @return T2& \n */", result);
     });
 
     test("* operator without params", () => {
         const result = testSetup.SetLine("R& operator*();").GetResult();
-        assert.equal("/**\n * @brief \n * \n * @return R& \n */", result);
+        assert.strictEqual("/**\n * @brief \n * \n * @return R& \n */", result);
     });
 
     test("& operator without params", () => {
         const result = testSetup.SetLine("R* operator&();").GetResult();
-        assert.equal("/**\n * @brief \n * \n * @return R* \n */", result);
+        assert.strictEqual("/**\n * @brief \n * \n * @return R* \n */", result);
     });
 
     test("->* operator", () => {
         const result = testSetup.SetLine("R& operator->*();").GetResult();
-        assert.equal("/**\n * @brief \n * \n * @return R& \n */", result);
+        assert.strictEqual("/**\n * @brief \n * \n * @return R& \n */", result);
     });
 
     test("-> operator", () => {
         const result = testSetup.SetLine("R* operator->();").GetResult();
-        assert.equal("/**\n * @brief \n * \n * @return R* \n */", result);
+        assert.strictEqual("/**\n * @brief \n * \n * @return R* \n */", result);
     });
 
     test("[] operator", () => {
         let result = testSetup.SetLine("R operator[](S b);").GetResult();
-        assert.equal("/**\n * @brief \n * \n * @param b \n * @return R \n */", result);
+        assert.strictEqual("/**\n * @brief \n * \n * @param b \n * @return R \n */", result);
 
         result = testSetup.SetLine("R operator[ ](S b);").GetResult();
-        assert.equal("/**\n * @brief \n * \n * @param b \n * @return R \n */", result);
+        assert.strictEqual("/**\n * @brief \n * \n * @param b \n * @return R \n */", result);
     });
 
     test("new operator", () => {
         const result = testSetup.SetLine("void* operator new ( std::size_t count );").GetResult();
-        assert.equal("/**\n * @brief \n * \n * @param count \n * @return void* \n */", result);
+        assert.strictEqual("/**\n * @brief \n * \n * @param count \n * @return void* \n */", result);
     });
 
     test("new[] operator", () => {
         let result = testSetup.SetLine("void* operator new[]( std::size_t count, std::align_val_t al);").GetResult();
-        assert.equal("/**\n * @brief \n * \n * @param count \n * @param al \n * @return void* \n */", result);
+        assert.strictEqual("/**\n * @brief \n * \n * @param count \n * @param al \n * @return void* \n */", result);
 
         result = testSetup.SetLine("void* operator new[ ]( std::size_t count, std::align_val_t al);").GetResult();
-        assert.equal("/**\n * @brief \n * \n * @param count \n * @param al \n * @return void* \n */", result);
+        assert.strictEqual("/**\n * @brief \n * \n * @param count \n * @param al \n * @return void* \n */", result);
     });
 
     test("delete operator", () => {
         const result = testSetup.SetLine("void operator delete(void* ptr, std::size_t sz, std::align_val_t al);")
             .GetResult();
-        assert.equal("/**\n * @brief \n * \n * @param ptr \n * @param sz \n * @param al \n */", result);
+        assert.strictEqual("/**\n * @brief \n * \n * @param ptr \n * @param sz \n * @param al \n */", result);
     });
 
     test("delete[] operator", () => {
         let result = testSetup.SetLine("void operator delete[] (void* ptr);").GetResult();
-        assert.equal("/**\n * @brief \n * \n * @param ptr \n */", result);
+        assert.strictEqual("/**\n * @brief \n * \n * @param ptr \n */", result);
 
         result = testSetup.SetLine("void operator delete [ ] (void* ptr);").GetResult();
-        assert.equal("/**\n * @brief \n * \n * @param ptr \n */", result);
+        assert.strictEqual("/**\n * @brief \n * \n * @param ptr \n */", result);
     });
 
     test("user literal operator", () => {
         let result = testSetup.SetLine("long double operator\"\"_My_C00l_Conversion(const char * str);").GetResult();
-        assert.equal("/**\n * @brief \n * \n * @param str \n * @return long double \n */", result);
+        assert.strictEqual("/**\n * @brief \n * \n * @param str \n * @return long double \n */", result);
 
         result = testSetup.SetLine("long double operator \"\"_My_C00l_Conversion(const char * str);").GetResult();
-        assert.equal("/**\n * @brief \n * \n * @param str \n * @return long double \n */", result);
+        assert.strictEqual("/**\n * @brief \n * \n * @param str \n * @return long double \n */", result);
 
         result = testSetup.SetLine("long double operator\"\"_My_C00l_Conversion (const char * str);").GetResult();
-        assert.equal("/**\n * @brief \n * \n * @param str \n * @return long double \n */", result);
+        assert.strictEqual("/**\n * @brief \n * \n * @param str \n * @return long double \n */", result);
     });
 
     test("Implicit conversion operator", () => {
         const result = testSetup.SetLine("operator int() const;").GetResult();
-        assert.equal("/**\n * @brief \n * \n * @return int \n */", result);
+        assert.strictEqual("/**\n * @brief \n * \n * @return int \n */", result);
     });
 
     test("Explicit conversion operator", () => {
         const result = testSetup.SetLine("explicit operator int() const;").GetResult();
-        assert.equal("/**\n * @brief \n * \n * @return int \n */", result);
+        assert.strictEqual("/**\n * @brief \n * \n * @return int \n */", result);
     });
 
     test("conversion operator to struct", () => {
         const result = testSetup.SetLine("explicit operator struct foo() const;").GetResult();
-        assert.equal("/**\n * @brief \n * \n * @return struct foo \n */", result);
+        assert.strictEqual("/**\n * @brief \n * \n * @return struct foo \n */", result);
     });
 
     test("conversion operator to struct pointer", () => {
         const result = testSetup.SetLine("explicit operator struct foo*() const;").GetResult();
-        assert.equal("/**\n * @brief \n * \n * @return struct foo* \n */", result);
+        assert.strictEqual("/**\n * @brief \n * \n * @return struct foo* \n */", result);
     });
 });

--- a/src/test/CppTests/Parameters.test.ts
+++ b/src/test/CppTests/Parameters.test.ts
@@ -19,275 +19,275 @@ suite("C++ - Parameters Tests", () => {
     // Tests
     test("No parameters", () => {
         const result = testSetup.SetLine("void foo();").GetResult();
-        assert.equal("/**\n * @brief \n * \n */", result);
+        assert.strictEqual("/**\n * @brief \n * \n */", result);
     });
 
     test("Single parameter", () => {
         const result = testSetup.SetLine("void foo(int a);").GetResult();
-        assert.equal("/**\n * @brief \n * \n * @param a \n */", result);
+        assert.strictEqual("/**\n * @brief \n * \n * @param a \n */", result);
     });
 
     test("Multiple parameters", () => {
         const result = testSetup.SetLine("void foo(int a, int b, int c);").GetResult();
-        assert.equal("/**\n * @brief \n * \n * @param a \n * @param b \n * @param c \n */", result);
+        assert.strictEqual("/**\n * @brief \n * \n * @param a \n * @param b \n * @param c \n */", result);
     });
 
     test("Parameters with numbers in them", () => {
         const result = testSetup.SetLine("void foo(int a1, int b23);").GetResult();
-        assert.equal("/**\n * @brief \n * \n * @param a1 \n * @param b23 \n */", result);
+        assert.strictEqual("/**\n * @brief \n * \n * @param a1 \n * @param b23 \n */", result);
     });
 
     test("Reference parameter", () => {
         const result = testSetup.SetLine("void foo(int& a);").GetResult();
-        assert.equal("/**\n * @brief \n * \n * @param a \n */", result);
+        assert.strictEqual("/**\n * @brief \n * \n * @param a \n */", result);
     });
 
     test("Reference parameter with unsigned interger qualifier", () => {
         const result = testSetup.SetLine("void foo(unsigned int& a);").GetResult();
-        assert.equal("/**\n * @brief \n * \n * @param a \n */", result);
+        assert.strictEqual("/**\n * @brief \n * \n * @param a \n */", result);
     });
 
     test("Reference parameter with const qualifier", () => {
         const result = testSetup.SetLine("void foo(const int& a);").GetResult();
-        assert.equal("/**\n * @brief \n * \n * @param a \n */", result);
+        assert.strictEqual("/**\n * @brief \n * \n * @param a \n */", result);
     });
 
     test("Reference parameter with const and interger qualifier", () => {
         const result = testSetup.SetLine("void foo(const unsigned int& a);").GetResult();
-        assert.equal("/**\n * @brief \n * \n * @param a \n */", result);
+        assert.strictEqual("/**\n * @brief \n * \n * @param a \n */", result);
     });
 
     test("Pointer parameter", () => {
         const result = testSetup.SetLine("void foo(int* a);").GetResult();
-        assert.equal("/**\n * @brief \n * \n * @param a \n */", result);
+        assert.strictEqual("/**\n * @brief \n * \n * @param a \n */", result);
     });
 
     test("Const parameter", () => {
         let result = testSetup.SetLine("void foo(const int a1);").GetResult();
-        assert.equal("/**\n * @brief \n * \n * @param a1 \n */", result);
+        assert.strictEqual("/**\n * @brief \n * \n * @param a1 \n */", result);
 
         result = testSetup.SetLine("void foo(int const a1);").GetResult();
-        assert.equal("/**\n * @brief \n * \n * @param a1 \n */", result);
+        assert.strictEqual("/**\n * @brief \n * \n * @param a1 \n */", result);
     });
 
     test("Struct parameter", () => {
         const result = testSetup.SetLine("void foo(int a1, int b23);").GetResult();
-        assert.equal("/**\n * @brief \n * \n * @param a1 \n * @param b23 \n */", result);
+        assert.strictEqual("/**\n * @brief \n * \n * @param a1 \n * @param b23 \n */", result);
     });
 
     test("Template parameter", () => {
         const result = testSetup.SetLine("void foo(Matrix<T, N, M> mat);").GetResult();
-        assert.equal("/**\n * @brief \n * \n * @param mat \n */", result);
+        assert.strictEqual("/**\n * @brief \n * \n * @param mat \n */", result);
     });
 
     test("Enum parameter", () => {
         const result = testSetup.SetLine("void foo(enum foo bar);").GetResult();
-        assert.equal("/**\n * @brief \n * \n * @param bar \n */", result);
+        assert.strictEqual("/**\n * @brief \n * \n * @param bar \n */", result);
     });
 
     test("Const parameter with const pointer to const pointer", () => {
         let result = testSetup.SetLine("void foo(const int * const * const a1);").GetResult();
-        assert.equal("/**\n * @brief \n * \n * @param a1 \n */", result);
+        assert.strictEqual("/**\n * @brief \n * \n * @param a1 \n */", result);
 
         result = testSetup.SetLine("void foo(int const * const * const a1);").GetResult();
-        assert.equal("/**\n * @brief \n * \n * @param a1 \n */", result);
+        assert.strictEqual("/**\n * @brief \n * \n * @param a1 \n */", result);
     });
 
     test("Fundamental return type with modifiers", () => {
         let result = testSetup.SetLine("void foo(unsigned int a);").GetResult();
-        assert.equal("/**\n * @brief \n * \n * @param a \n */", result);
+        assert.strictEqual("/**\n * @brief \n * \n * @param a \n */", result);
 
         result = testSetup.SetLine("void foo(unsigned short int a);").GetResult();
-        assert.equal("/**\n * @brief \n * \n * @param a \n */", result);
+        assert.strictEqual("/**\n * @brief \n * \n * @param a \n */", result);
 
         result = testSetup.SetLine("void foo(signed short a);").GetResult();
-        assert.equal("/**\n * @brief \n * \n * @param a \n */", result);
+        assert.strictEqual("/**\n * @brief \n * \n * @param a \n */", result);
 
         result = testSetup.SetLine("void foo(long a);").GetResult();
-        assert.equal("/**\n * @brief \n * \n * @param a \n */", result);
+        assert.strictEqual("/**\n * @brief \n * \n * @param a \n */", result);
 
         result = testSetup.SetLine("void foo(unsigned long long int a);").GetResult();
-        assert.equal("/**\n * @brief \n * \n * @param a \n */", result);
+        assert.strictEqual("/**\n * @brief \n * \n * @param a \n */", result);
 
         result = testSetup.SetLine("void foo(signed a);").GetResult();
-        assert.equal("/**\n * @brief \n * \n * @param a \n */", result);
+        assert.strictEqual("/**\n * @brief \n * \n * @param a \n */", result);
 
         result = testSetup.SetLine("void foo(unsigned a);").GetResult();
-        assert.equal("/**\n * @brief \n * \n * @param a \n */", result);
+        assert.strictEqual("/**\n * @brief \n * \n * @param a \n */", result);
 
         result = testSetup.SetLine("void foo(unsigned char a);").GetResult();
-        assert.equal("/**\n * @brief \n * \n * @param a \n */", result);
+        assert.strictEqual("/**\n * @brief \n * \n * @param a \n */", result);
 
         result = testSetup.SetLine("void foo(long double a);").GetResult();
-        assert.equal("/**\n * @brief \n * \n * @param a \n */", result);
+        assert.strictEqual("/**\n * @brief \n * \n * @param a \n */", result);
 
         result = testSetup.SetLine("void foo(long unsigned unsigned_a);").GetResult();
-        assert.equal("/**\n * @brief \n * \n * @param unsigned_a \n */", result);
+        assert.strictEqual("/**\n * @brief \n * \n * @param unsigned_a \n */", result);
     });
 
     test("Parameter type in namespace", () => {
         const result = testSetup.SetLine("void foo(MyNamespace::Foo a1);").GetResult();
-        assert.equal("/**\n * @brief \n * \n * @param a1 \n */", result);
+        assert.strictEqual("/**\n * @brief \n * \n * @param a1 \n */", result);
     });
 
     test("Parameter template type in namespace", () => {
         const result = testSetup.SetLine("void foo(Math::Matrix<A, B, C> mat);").GetResult();
-        assert.equal("/**\n * @brief \n * \n * @param mat \n */", result);
+        assert.strictEqual("/**\n * @brief \n * \n * @param mat \n */", result);
     });
 
     test("Parameter template type within templated namespace", () => {
         const result = testSetup.SetLine("void foo(Matrix<A, B, C>::Matrix<A, B, C> mat);").GetResult();
-        assert.equal("/**\n * @brief \n * \n * @param mat \n */", result);
+        assert.strictEqual("/**\n * @brief \n * \n * @param mat \n */", result);
     });
 
     test("Parameter type in nested namespacee", () => {
         const result = testSetup.SetLine("void foo( Math::LA::Matrix<A, B, C> mat);").GetResult();
-        assert.equal("/**\n * @brief \n * \n * @param mat \n */", result);
+        assert.strictEqual("/**\n * @brief \n * \n * @param mat \n */", result);
     });
 
     test("Parameter with default char literal", () => {
         let result = testSetup.SetLine("void foo(char a1 = 'a', int b);").GetResult();
-        assert.equal("/**\n * @brief \n * \n * @param a1 \n * @param b \n */", result);
+        assert.strictEqual("/**\n * @brief \n * \n * @param a1 \n * @param b \n */", result);
 
         result = testSetup.SetLine("void foo(char a1 = u'b', int b);").GetResult();
-        assert.equal("/**\n * @brief \n * \n * @param a1 \n * @param b \n */", result);
+        assert.strictEqual("/**\n * @brief \n * \n * @param a1 \n * @param b \n */", result);
 
         result = testSetup.SetLine("void foo(char a1 = u8'b', int b);").GetResult();
-        assert.equal("/**\n * @brief \n * \n * @param a1 \n * @param b \n */", result);
+        assert.strictEqual("/**\n * @brief \n * \n * @param a1 \n * @param b \n */", result);
 
         result = testSetup.SetLine("void foo(char a1 = U'a', int b);").GetResult();
-        assert.equal("/**\n * @brief \n * \n * @param a1 \n * @param b \n */", result);
+        assert.strictEqual("/**\n * @brief \n * \n * @param a1 \n * @param b \n */", result);
 
         result = testSetup.SetLine("void foo(char a1 = l',', int b);").GetResult();
-        assert.equal("/**\n * @brief \n * \n * @param a1 \n * @param b \n */", result);
+        assert.strictEqual("/**\n * @brief \n * \n * @param a1 \n * @param b \n */", result);
 
         result = testSetup.SetLine("void foo(int a1 = 'ab', int b);").GetResult();
-        assert.equal("/**\n * @brief \n * \n * @param a1 \n * @param b \n */", result);
+        assert.strictEqual("/**\n * @brief \n * \n * @param a1 \n * @param b \n */", result);
     });
 
     test("Parameter with default string literal", () => {
         let result = testSetup.SetLine("void foo(std::string a1 = \"bar\", int b);").GetResult();
-        assert.equal("/**\n * @brief \n * \n * @param a1 \n * @param b \n */", result);
+        assert.strictEqual("/**\n * @brief \n * \n * @param a1 \n * @param b \n */", result);
 
         result = testSetup.SetLine("void foo(std::string a1 = u\"bar, test\", int b);").GetResult();
-        assert.equal("/**\n * @brief \n * \n * @param a1 \n * @param b \n */", result);
+        assert.strictEqual("/**\n * @brief \n * \n * @param a1 \n * @param b \n */", result);
 
         result = testSetup.SetLine("void foo(std::string a1 = u8\"bar\", int b);").GetResult();
-        assert.equal("/**\n * @brief \n * \n * @param a1 \n * @param b \n */", result);
+        assert.strictEqual("/**\n * @brief \n * \n * @param a1 \n * @param b \n */", result);
 
         result = testSetup.SetLine("void foo(std::string a1 = U\"bar\", int b);").GetResult();
-        assert.equal("/**\n * @brief \n * \n * @param a1 \n * @param b \n */", result);
+        assert.strictEqual("/**\n * @brief \n * \n * @param a1 \n * @param b \n */", result);
 
         result = testSetup.SetLine("void foo(std::string a1 = l\"bar\", int b);").GetResult();
-        assert.equal("/**\n * @brief \n * \n * @param a1 \n * @param b \n */", result);
+        assert.strictEqual("/**\n * @brief \n * \n * @param a1 \n * @param b \n */", result);
 
         result = testSetup.SetLine("void foo(std::string a1 = R\"(bar\\t\\\")\", int b);").GetResult();
-        assert.equal("/**\n * @brief \n * \n * @param a1 \n * @param b \n */", result);
+        assert.strictEqual("/**\n * @brief \n * \n * @param a1 \n * @param b \n */", result);
     });
 
     test("Parameter with default integer literal", () => {
         let result = testSetup.SetLine("void foo(int a1 = 1337, int b);").GetResult();
-        assert.equal("/**\n * @brief \n * \n * @param a1 \n * @param b \n */", result);
+        assert.strictEqual("/**\n * @brief \n * \n * @param a1 \n * @param b \n */", result);
 
         result = testSetup.SetLine("void foo(int a1 = 01337, int b);").GetResult();
-        assert.equal("/**\n * @brief \n * \n * @param a1 \n * @param b \n */", result);
+        assert.strictEqual("/**\n * @brief \n * \n * @param a1 \n * @param b \n */", result);
 
         result = testSetup.SetLine("void foo(int a1 = 1337, int b);").GetResult();
-        assert.equal("/**\n * @brief \n * \n * @param a1 \n * @param b \n */", result);
+        assert.strictEqual("/**\n * @brief \n * \n * @param a1 \n * @param b \n */", result);
 
         result = testSetup.SetLine("void foo(int a1 = 0x0FAB, int b);").GetResult();
-        assert.equal("/**\n * @brief \n * \n * @param a1 \n * @param b \n */", result);
+        assert.strictEqual("/**\n * @brief \n * \n * @param a1 \n * @param b \n */", result);
 
         result = testSetup.SetLine("void foo(int a1 = 0X0FAB, int b);").GetResult();
-        assert.equal("/**\n * @brief \n * \n * @param a1 \n * @param b \n */", result);
+        assert.strictEqual("/**\n * @brief \n * \n * @param a1 \n * @param b \n */", result);
 
         result = testSetup.SetLine("void foo(std::uint8_t a1 = 0b110011, int b);").GetResult();
-        assert.equal("/**\n * @brief \n * \n * @param a1 \n * @param b \n */", result);
+        assert.strictEqual("/**\n * @brief \n * \n * @param a1 \n * @param b \n */", result);
 
         result = testSetup.SetLine("void foo(std::byte a1 = 0B11111, int b);").GetResult();
-        assert.equal("/**\n * @brief \n * \n * @param a1 \n * @param b \n */", result);
+        assert.strictEqual("/**\n * @brief \n * \n * @param a1 \n * @param b \n */", result);
 
         result = testSetup.SetLine("void foo(long a1 = 1337l, int b);").GetResult();
-        assert.equal("/**\n * @brief \n * \n * @param a1 \n * @param b \n */", result);
+        assert.strictEqual("/**\n * @brief \n * \n * @param a1 \n * @param b \n */", result);
 
         result = testSetup.SetLine("void foo(long long a1 = 1337ll, int b);").GetResult();
-        assert.equal("/**\n * @brief \n * \n * @param a1 \n * @param b \n */", result);
+        assert.strictEqual("/**\n * @brief \n * \n * @param a1 \n * @param b \n */", result);
 
         result = testSetup.SetLine("void foo(unsigned long long a1 = 1337ull, int b);").GetResult();
-        assert.equal("/**\n * @brief \n * \n * @param a1 \n * @param b \n */", result);
+        assert.strictEqual("/**\n * @brief \n * \n * @param a1 \n * @param b \n */", result);
 
         result = testSetup.SetLine("void foo(long a1 = 1337L, int b);").GetResult();
-        assert.equal("/**\n * @brief \n * \n * @param a1 \n * @param b \n */", result);
+        assert.strictEqual("/**\n * @brief \n * \n * @param a1 \n * @param b \n */", result);
 
         result = testSetup.SetLine("void foo(long long a1 = 1337LL, int b);").GetResult();
-        assert.equal("/**\n * @brief \n * \n * @param a1 \n * @param b \n */", result);
+        assert.strictEqual("/**\n * @brief \n * \n * @param a1 \n * @param b \n */", result);
 
         result = testSetup.SetLine("void foo(unsigned long long a1 = 1337ULL, int b);").GetResult();
-        assert.equal("/**\n * @brief \n * \n * @param a1 \n * @param b \n */", result);
+        assert.strictEqual("/**\n * @brief \n * \n * @param a1 \n * @param b \n */", result);
     });
 
     test("Parameter with default floating point literal", () => {
         let result = testSetup.SetLine("void foo(double a1 = 1e10, int b);").GetResult();
-        assert.equal("/**\n * @brief \n * \n * @param a1 \n * @param b \n */", result);
+        assert.strictEqual("/**\n * @brief \n * \n * @param a1 \n * @param b \n */", result);
 
         result = testSetup.SetLine("void foo(double a1 = 1., int b);").GetResult();
-        assert.equal("/**\n * @brief \n * \n * @param a1 \n * @param b \n */", result);
+        assert.strictEqual("/**\n * @brief \n * \n * @param a1 \n * @param b \n */", result);
 
         result = testSetup.SetLine("void foo(double a1 = .1, int b);").GetResult();
-        assert.equal("/**\n * @brief \n * \n * @param a1 \n * @param b \n */", result);
+        assert.strictEqual("/**\n * @brief \n * \n * @param a1 \n * @param b \n */", result);
 
         result = testSetup.SetLine("void foo(double a1 = 0.1e-1, int b);").GetResult();
-        assert.equal("/**\n * @brief \n * \n * @param a1 \n * @param b \n */", result);
+        assert.strictEqual("/**\n * @brief \n * \n * @param a1 \n * @param b \n */", result);
 
         result = testSetup.SetLine("void foo(float a1 = 1.0f, int b);").GetResult();
-        assert.equal("/**\n * @brief \n * \n * @param a1 \n * @param b \n */", result);
+        assert.strictEqual("/**\n * @brief \n * \n * @param a1 \n * @param b \n */", result);
 
         result = testSetup.SetLine("void foo(float a1 = 1.0F, int b);").GetResult();
-        assert.equal("/**\n * @brief \n * \n * @param a1 \n * @param b \n */", result);
+        assert.strictEqual("/**\n * @brief \n * \n * @param a1 \n * @param b \n */", result);
 
         result = testSetup.SetLine("void foo(long double a1 = 1.0lf, int b);").GetResult();
-        assert.equal("/**\n * @brief \n * \n * @param a1 \n * @param b \n */", result);
+        assert.strictEqual("/**\n * @brief \n * \n * @param a1 \n * @param b \n */", result);
 
         result = testSetup.SetLine("void foo(long double a1 = 1.0LF, int b);").GetResult();
-        assert.equal("/**\n * @brief \n * \n * @param a1 \n * @param b \n */", result);
+        assert.strictEqual("/**\n * @brief \n * \n * @param a1 \n * @param b \n */", result);
 
         result = testSetup.SetLine("void foo(double a1 = 0xa.bp10, int b);").GetResult();
-        assert.equal("/**\n * @brief \n * \n * @param a1 \n * @param b \n */", result);
+        assert.strictEqual("/**\n * @brief \n * \n * @param a1 \n * @param b \n */", result);
 
         result = testSetup.SetLine("void foo(double a1 = 0xa.bp10l, int b);").GetResult();
-        assert.equal("/**\n * @brief \n * \n * @param a1 \n * @param b \n */", result);
+        assert.strictEqual("/**\n * @brief \n * \n * @param a1 \n * @param b \n */", result);
     });
 
     test("Parameter with default compound literal", () => {
         const result = testSetup.SetLine("void foo(struct Bar a1 = {2, 3}, int b);").GetResult();
-        assert.equal("/**\n * @brief \n * \n * @param a1 \n * @param b \n */", result);
+        assert.strictEqual("/**\n * @brief \n * \n * @param a1 \n * @param b \n */", result);
     });
 
     test("Parameter with default template function call", () => {
         const result = testSetup.SetLine("void foo(struct Bar a1 = test::baz<3, 2, 5>(23), int b);").GetResult();
-        assert.equal("/**\n * @brief \n * \n * @param a1 \n * @param b \n */", result);
+        assert.strictEqual("/**\n * @brief \n * \n * @param a1 \n * @param b \n */", result);
     });
 
     test("Parameter with default user defined literal.", () => {
         const result = testSetup.SetLine("void foo(double a1 = 0xa.bp10l_deg_test, int b);").GetResult();
-        assert.equal("/**\n * @brief \n * \n * @param a1 \n * @param b \n */", result);
+        assert.strictEqual("/**\n * @brief \n * \n * @param a1 \n * @param b \n */", result);
     });
 
     test("Member pointer as parameter", () => {
         const result = testSetup.SetLine("void test(int foo::* memberPointer);").GetResult();
-        assert.equal("/**\n * @brief \n * \n * @param memberPointer \n */", result);
+        assert.strictEqual("/**\n * @brief \n * \n * @param memberPointer \n */", result);
     });
 
     test("Restrict keyword", () => {
         const result = testSetup.SetLine("void some_function(char *restrict buf, const size_t buflen);").GetResult();
-        assert.equal("/**\n * @brief \n * \n * @param buf \n * @param buflen \n */", result);
+        assert.strictEqual("/**\n * @brief \n * \n * @param buf \n * @param buflen \n */", result);
     });
 
     test("Type as variable name", () => {
         let result = testSetup.SetLine("void MapPoint(double latitude, double longtitude) const;").GetResult();
-        assert.equal("/**\n * @brief \n * \n * @param latitude \n * @param longtitude \n */", result);
+        assert.strictEqual("/**\n * @brief \n * \n * @param latitude \n * @param longtitude \n */", result);
 
         result = testSetup.SetLine("void MapPoint(double latitude, double long int floattitude) const;").GetResult();
-        assert.equal("/**\n * @brief \n * \n * @param latitude \n * @param floattitude \n */", result);
+        assert.strictEqual("/**\n * @brief \n * \n * @param latitude \n * @param floattitude \n */", result);
     });
 });

--- a/src/test/CppTests/Preprocessor.test.ts
+++ b/src/test/CppTests/Preprocessor.test.ts
@@ -18,7 +18,7 @@ suite("C++ - Preprocessor Tests", () => {
     // Tests
     test("Macro", () => {
         const result = testSetup.GetResult();
-        assert.equal("/**\n * @brief \n * \n */", result);
+        assert.strictEqual("/**\n * @brief \n * \n */", result);
     });
 
     // Tests
@@ -28,7 +28,7 @@ suite("C++ - Preprocessor Tests", () => {
             "/**",
             " */",
         ]).GetResult();
-        assert.equal("/**\n * @brief \n * \n */", result);
+        assert.strictEqual("/**\n * @brief \n * \n */", result);
     });
 
     // These two tests don't seem to belong here but the behavior they're testing only is reproducable
@@ -38,7 +38,7 @@ suite("C++ - Preprocessor Tests", () => {
             "*/", // simulate an auto generated closing block comment
             "void foo(int bar);",
         ]).GetResult();
-        assert.equal("/**\n * @brief \n * \n * @param bar \n */", result);
+        assert.strictEqual("/**\n * @brief \n * \n * @param bar \n */", result);
     });
 
     test("don't detect closing */", () => {
@@ -47,6 +47,6 @@ suite("C++ - Preprocessor Tests", () => {
             " */",
             "void foo(int bar);",
         ]).GetResult();
-        assert.equal("/**\n * @brief \n * \n */", result);
+        assert.strictEqual("/**\n * @brief \n * \n */", result);
     });
 });

--- a/src/test/CppTests/ReturnTypes.test.ts
+++ b/src/test/CppTests/ReturnTypes.test.ts
@@ -19,133 +19,133 @@ suite("C++ - Return type Tests", () => {
     // Tests
     test("Void return", () => {
         const result = testSetup.SetLine("void foo();").GetResult();
-        assert.equal("/**\n * @brief \n * \n */", result);
+        assert.strictEqual("/**\n * @brief \n * \n */", result);
     });
 
     test("Void pointer return", () => {
         const result = testSetup.SetLine("void* foo();").GetResult();
-        assert.equal("/**\n * @brief \n * \n * @return void* \n */", result);
+        assert.strictEqual("/**\n * @brief \n * \n * @return void* \n */", result);
     });
 
     test("Reference return", () => {
         const result = testSetup.SetLine("int& foo();").GetResult();
-        assert.equal("/**\n * @brief \n * \n * @return int& \n */", result);
+        assert.strictEqual("/**\n * @brief \n * \n * @return int& \n */", result);
     });
 
     test("Simple type return", () => {
         const result = testSetup.SetLine("int foo();").GetResult();
-        assert.equal("/**\n * @brief \n * \n * @return int \n */", result);
+        assert.strictEqual("/**\n * @brief \n * \n * @return int \n */", result);
     });
 
     test("Bool return type", () => {
         const result = testSetup.SetLine("bool foo();").GetResult();
-        assert.equal("/**\n * @brief \n * \n * @return true \n * @return false \n */", result);
+        assert.strictEqual("/**\n * @brief \n * \n * @return true \n * @return false \n */", result);
     });
 
     test("Pointer return type", () => {
         const result = testSetup.SetLine("int* foo();").GetResult();
-        assert.equal("/**\n * @brief \n * \n * @return int* \n */", result);
+        assert.strictEqual("/**\n * @brief \n * \n * @return int* \n */", result);
     });
 
     test("Bool pointer return type", () => {
         const result = testSetup.SetLine("bool* foo();").GetResult();
-        assert.equal("/**\n * @brief \n * \n * @return true \n * @return false \n */", result);
+        assert.strictEqual("/**\n * @brief \n * \n * @return true \n * @return false \n */", result);
     });
 
     test("Struct pointer return type", () => {
         const result = testSetup.SetLine("struct foo* foo();").GetResult();
-        assert.equal("/**\n * @brief \n * \n * @return struct foo* \n */", result);
+        assert.strictEqual("/**\n * @brief \n * \n * @return struct foo* \n */", result);
     });
 
     test("Struct return type", () => {
         const result = testSetup.SetLine("struct Bar* foo();").GetResult();
-        assert.equal("/**\n * @brief \n * \n * @return struct Bar* \n */", result);
+        assert.strictEqual("/**\n * @brief \n * \n * @return struct Bar* \n */", result);
     });
 
     test("Return type with keywords", () => {
         const result = testSetup.SetLine("static constexpr inline Bar* const foo() "
             + "const;").GetResult();
-        assert.equal("/**\n * @brief \n * \n * @return constexpr Bar* const \n */", result);
+        assert.strictEqual("/**\n * @brief \n * \n * @return constexpr Bar* const \n */", result);
     });
 
     test("Return type struct with keywords", () => {
         const result = testSetup.SetLine("static constexpr inline struct Bar* foo() "
             + "const;").GetResult();
-        assert.equal("/**\n * @brief \n * \n * @return constexpr struct Bar* \n */", result);
+        assert.strictEqual("/**\n * @brief \n * \n * @return constexpr struct Bar* \n */", result);
     });
 
     test("Const with const pointer to const pointer return type", () => {
         let result = testSetup.SetLine("const int* const* const foo();").GetResult();
-        assert.equal("/**\n * @brief \n * \n * @return const int* const* const \n */", result);
+        assert.strictEqual("/**\n * @brief \n * \n * @return const int* const* const \n */", result);
 
         result = testSetup.SetLine("int const* const* const foo();").GetResult();
-        assert.equal("/**\n * @brief \n * \n * @return int const* const* const \n */", result);
+        assert.strictEqual("/**\n * @brief \n * \n * @return int const* const* const \n */", result);
     });
 
     test("Fundamental return type with modifiers", () => {
         let result = testSetup.SetLine("unsigned int foo();").GetResult();
-        assert.equal("/**\n * @brief \n * \n * @return unsigned int \n */", result);
+        assert.strictEqual("/**\n * @brief \n * \n * @return unsigned int \n */", result);
 
         result = testSetup.SetLine("unsigned short int foo();").GetResult();
-        assert.equal("/**\n * @brief \n * \n * @return unsigned short int \n */", result);
+        assert.strictEqual("/**\n * @brief \n * \n * @return unsigned short int \n */", result);
 
         result = testSetup.SetLine("signed short foo();").GetResult();
-        assert.equal("/**\n * @brief \n * \n * @return signed short \n */", result);
+        assert.strictEqual("/**\n * @brief \n * \n * @return signed short \n */", result);
 
         result = testSetup.SetLine("long foo();").GetResult();
-        assert.equal("/**\n * @brief \n * \n * @return long \n */", result);
+        assert.strictEqual("/**\n * @brief \n * \n * @return long \n */", result);
 
         result = testSetup.SetLine("unsigned long long int foo();").GetResult();
-        assert.equal("/**\n * @brief \n * \n * @return unsigned long long int \n */", result);
+        assert.strictEqual("/**\n * @brief \n * \n * @return unsigned long long int \n */", result);
 
         result = testSetup.SetLine("signed foo();").GetResult();
-        assert.equal("/**\n * @brief \n * \n * @return signed \n */", result);
+        assert.strictEqual("/**\n * @brief \n * \n * @return signed \n */", result);
 
         result = testSetup.SetLine("unsigned foo();").GetResult();
-        assert.equal("/**\n * @brief \n * \n * @return unsigned \n */", result);
+        assert.strictEqual("/**\n * @brief \n * \n * @return unsigned \n */", result);
 
         result = testSetup.SetLine("unsigned char foo();").GetResult();
-        assert.equal("/**\n * @brief \n * \n * @return unsigned char \n */", result);
+        assert.strictEqual("/**\n * @brief \n * \n * @return unsigned char \n */", result);
 
         result = testSetup.SetLine("long double foo();").GetResult();
-        assert.equal("/**\n * @brief \n * \n * @return long double \n */", result);
+        assert.strictEqual("/**\n * @brief \n * \n * @return long double \n */", result);
 
         result = testSetup.SetLine("long unsigned unsigned_foo();").GetResult();
-        assert.equal("/**\n * @brief \n * \n * @return long unsigned \n */", result);
+        assert.strictEqual("/**\n * @brief \n * \n * @return long unsigned \n */", result);
     });
 
     test("Function in namespace", () => {
         const result = testSetup.SetLine("int MyClass::foo();").GetResult();
-        assert.equal("/**\n * @brief \n * \n * @return int \n */", result);
+        assert.strictEqual("/**\n * @brief \n * \n * @return int \n */", result);
     });
 
     test("Return Type in namespace", () => {
         const result = testSetup.SetLine("MyNamespace::Foo MakeFoo();").GetResult();
-        assert.equal("/**\n * @brief \n * \n * @return MyNamespace::Foo \n */", result);
+        assert.strictEqual("/**\n * @brief \n * \n * @return MyNamespace::Foo \n */", result);
     });
 
     test("Template return type", () => {
         const result = testSetup.SetLine("Matrix<A, B, C> foo();").GetResult();
-        assert.equal("/**\n * @brief \n * \n * @return Matrix<A, B, C> \n */", result);
+        assert.strictEqual("/**\n * @brief \n * \n * @return Matrix<A, B, C> \n */", result);
     });
 
     test("Template return type within templated namespace", () => {
         const result = testSetup.SetLine("Matrix<A, B, C>::Matrix<A, B, C> foo();").GetResult();
-        assert.equal("/**\n * @brief \n * \n * @return Matrix<A, B, C>::Matrix<A, B, C> \n */", result);
+        assert.strictEqual("/**\n * @brief \n * \n * @return Matrix<A, B, C>::Matrix<A, B, C> \n */", result);
     });
 
     test("Function in templated namespace", () => {
         const result = testSetup.SetLine("int Matrix<A, B, C>::foo();").GetResult();
-        assert.equal("/**\n * @brief \n * \n * @return int \n */", result);
+        assert.strictEqual("/**\n * @brief \n * \n * @return int \n */", result);
     });
 
     test("Function with nested namespacee", () => {
         const result = testSetup.SetLine("int Math::LA::Matrix<A, B, C>::foo();").GetResult();
-        assert.equal("/**\n * @brief \n * \n * @return int \n */", result);
+        assert.strictEqual("/**\n * @brief \n * \n * @return int \n */", result);
     });
 
     test("Return Type in nested namespace", () => {
         const result = testSetup.SetLine("Math::LA::Matrix<A, B, C> foo();").GetResult();
-        assert.equal("/**\n * @brief \n * \n * @return Math::LA::Matrix<A, B, C> \n */", result);
+        assert.strictEqual("/**\n * @brief \n * \n * @return Math::LA::Matrix<A, B, C> \n */", result);
     });
 });

--- a/src/test/CppTests/SmartText.test.ts
+++ b/src/test/CppTests/SmartText.test.ts
@@ -19,97 +19,97 @@ suite("Smart Text Tests", () => {
     test("Disable smart text Ctor", () => {
         testSetup.cfg.Generic.generateSmartText = false;
         const result = testSetup.SetLine("Foo();").GetResult();
-        assert.equal("/**\n * @brief \n * \n */", result);
+        assert.strictEqual("/**\n * @brief \n * \n */", result);
     });
 
     test("Disable smart text Dtor", () => {
         testSetup.cfg.Generic.generateSmartText = false;
         const result = testSetup.SetLine("~Foo();").GetResult();
-        assert.equal("/**\n * @brief \n * \n */", result);
+        assert.strictEqual("/**\n * @brief \n * \n */", result);
     });
 
     test("Disable smart text getter", () => {
         testSetup.cfg.Generic.generateSmartText = false;
         const result = testSetup.SetLine("int getFoo();").GetResult();
-        assert.equal("/**\n * @brief \n * \n * @return int \n */", result);
+        assert.strictEqual("/**\n * @brief \n * \n * @return int \n */", result);
     });
 
     test("Disable smart text setter", () => {
         testSetup.cfg.Generic.generateSmartText = false;
         const result = testSetup.SetLine("void setFoo(int foo);").GetResult();
-        assert.equal("/**\n * @brief \n * \n * @param foo \n */", result);
+        assert.strictEqual("/**\n * @brief \n * \n * @param foo \n */", result);
     });
 
     test("Disable smart text factory method", () => {
         testSetup.cfg.Generic.generateSmartText = false;
         const result = testSetup.SetLine("int createFoo();").GetResult();
-        assert.equal("/**\n * @brief \n * \n * @return int \n */", result);
+        assert.strictEqual("/**\n * @brief \n * \n * @return int \n */", result);
     });
 
     test("Standard smart text Ctor", () => {
         testSetup.cfg.Generic.generateSmartText = true;
         const result = testSetup.SetLine("Foo();").GetResult();
-        assert.equal("/**\n * @brief Construct a new Foo object\n * \n */", result);
+        assert.strictEqual("/**\n * @brief Construct a new Foo object\n * \n */", result);
     });
 
     test("Standard smart text Dtor", () => {
         testSetup.cfg.Generic.generateSmartText = true;
         const result = testSetup.SetLine("~Foo();").GetResult();
-        assert.equal("/**\n * @brief Destroy the Foo object\n * \n */", result);
+        assert.strictEqual("/**\n * @brief Destroy the Foo object\n * \n */", result);
     });
 
     test("Standard smart text getter", () => {
         testSetup.cfg.Generic.generateSmartText = true;
         const result = testSetup.SetLine("int getFoo();").GetResult();
-        assert.equal("/**\n * @brief Get the Foo object\n * \n * @return int \n */", result);
+        assert.strictEqual("/**\n * @brief Get the Foo object\n * \n * @return int \n */", result);
     });
 
     test("Standard smart text setter", () => {
         testSetup.cfg.Generic.generateSmartText = true;
         const result = testSetup.SetLine("void setFoo(int foo);").GetResult();
-        assert.equal("/**\n * @brief Set the Foo object\n * \n * @param foo \n */", result);
+        assert.strictEqual("/**\n * @brief Set the Foo object\n * \n * @param foo \n */", result);
     });
 
     test("Standard smart text factory method", () => {
         testSetup.cfg.Generic.generateSmartText = true;
         const result = testSetup.SetLine("int createFoo();").GetResult();
-        assert.equal("/**\n * @brief Create a Foo object\n * \n * @return int \n */", result);
+        assert.strictEqual("/**\n * @brief Create a Foo object\n * \n * @return int \n */", result);
     });
 
     test("Casing text split: SCREAMING_SNAKE", () => {
         testSetup.cfg.Generic.generateSmartText = true;
         const result = testSetup.SetLine("int CREATE_FOO();").GetResult();
-        assert.equal("/**\n * @brief Create a foo object\n * \n * @return int \n */", result);
+        assert.strictEqual("/**\n * @brief Create a foo object\n * \n * @return int \n */", result);
     });
 
     test("Casing text split: snake_case", () => {
         testSetup.cfg.Generic.generateSmartText = true;
         const result = testSetup.SetLine("int create_foo();").GetResult();
-        assert.equal("/**\n * @brief Create a foo object\n * \n * @return int \n */", result);
+        assert.strictEqual("/**\n * @brief Create a foo object\n * \n * @return int \n */", result);
     });
 
     test("Casing text split: PascalCase", () => {
         testSetup.cfg.Generic.generateSmartText = true;
         const result = testSetup.SetLine("int CreateFoo();").GetResult();
-        assert.equal("/**\n * @brief Create a Foo object\n * \n * @return int \n */", result);
+        assert.strictEqual("/**\n * @brief Create a Foo object\n * \n * @return int \n */", result);
     });
 
     test("Casing text split: camelCase", () => {
         testSetup.cfg.Generic.generateSmartText = true;
         const result = testSetup.SetLine("int createFoo();").GetResult();
-        assert.equal("/**\n * @brief Create a Foo object\n * \n * @return int \n */", result);
+        assert.strictEqual("/**\n * @brief Create a Foo object\n * \n * @return int \n */", result);
     });
 
     test("Casing text split: UPPERCASE", () => {
         testSetup.cfg.Generic.generateSmartText = true;
         const result = testSetup.SetLine("int CREATEFOO();").GetResult();
-        assert.equal("/**\n * @brief Create a FOO object\n * \n * @return int \n */", result);
+        assert.strictEqual("/**\n * @brief Create a FOO object\n * \n * @return int \n */", result);
     });
 
     test("Casing text split: UnCertain_CASE", () => {
         testSetup.cfg.Generic.generateSmartText = true;
         const result = testSetup.SetLine("int Create_FOO();").GetResult();
-        assert.equal("/**\n * @brief \n * \n * @return int \n */", result);
+        assert.strictEqual("/**\n * @brief \n * \n * @return int \n */", result);
     });
 
     test("Casing text split: unidentifieable", () => {
@@ -117,22 +117,22 @@ suite("Smart Text Tests", () => {
 
         // SCREAMING_SNAKE
         let result = testSetup.SetLine("int CREATE_foo();").GetResult();
-        assert.equal("/**\n * @brief \n * \n * @return int \n */", result);
+        assert.strictEqual("/**\n * @brief \n * \n * @return int \n */", result);
 
         // snake_case
         result = testSetup.SetLine("int create_FOO();").GetResult();
-        assert.equal("/**\n * @brief \n * \n * @return int \n */", result);
+        assert.strictEqual("/**\n * @brief \n * \n * @return int \n */", result);
 
         // Pascal
         result = testSetup.SetLine("int Createfoo();").GetResult();
-        assert.equal("/**\n * @brief \n * \n * @return int \n */", result);
+        assert.strictEqual("/**\n * @brief \n * \n * @return int \n */", result);
 
         // camel
         result = testSetup.SetLine("int createFOO();").GetResult();
-        assert.equal("/**\n * @brief \n * \n * @return int \n */", result);
+        assert.strictEqual("/**\n * @brief \n * \n * @return int \n */", result);
 
         // UPPER???
         result = testSetup.SetLine("int CREATE_();").GetResult();
-        assert.equal("/**\n * @brief \n * \n * @return int \n */", result);
+        assert.strictEqual("/**\n * @brief \n * \n * @return int \n */", result);
     });
 });

--- a/src/test/CppTests/Templates.test.ts
+++ b/src/test/CppTests/Templates.test.ts
@@ -20,39 +20,39 @@ suite("C++ - Template tests", () => {
         const result = testSetup.SetLine("template<typename T, std::size_t M, std::size_t N,"
             + "typename = typename std::enable_if<std::is_arithmetic<T>::value, T>::type>"
             + "class matrix {").GetResult();
-        assert.equal("/**\n * @brief \n * \n * @tparam T \n * @tparam M \n * @tparam N \n * "
+        assert.strictEqual("/**\n * @brief \n * \n * @tparam T \n * @tparam M \n * @tparam N \n * "
             + "@tparam std::enable_if<std::is_arithmetic<T>::value, T>::type \n */", result);
     });
 
     test("Template function", () => {
         const result = testSetup.SetLine("template<typename T, typename S>\nT f(T a, S b);").GetResult();
-        assert.equal("/**\n * @brief \n * \n * @tparam T \n * @tparam S \n * @param a \n * "
+        assert.strictEqual("/**\n * @brief \n * \n * @tparam T \n * @tparam S \n * @param a \n * "
             + "@param b \n * @return T \n */", result);
     });
 
     test("Double template", () => {
         const result = testSetup.SetLine("template<typename T>\ntemplate<typename S>\nT f(T a, S b);").GetResult();
-        assert.equal("/**\n * @brief \n * \n * @tparam T \n * @tparam S \n * @param a \n * "
+        assert.strictEqual("/**\n * @brief \n * \n * @tparam T \n * @tparam S \n * @param a \n * "
             + "@param b \n * @return T \n */", result);
     });
 
     test("Template struct", () => {
         const result = testSetup.SetLine("template<typename T, std::size_t m, std::size_t n>\n"
             + "struct myStruct {").GetResult();
-        assert.equal("/**\n * @brief \n * \n * @tparam T \n * @tparam m \n * @tparam n \n */", result);
+        assert.strictEqual("/**\n * @brief \n * \n * @tparam T \n * @tparam m \n * @tparam n \n */", result);
     });
 
     test("Variadic template", () => {
         const result = testSetup.SetLine("template<typename T, typename... Args>"
             + "\nT adder(T first, Args... args);").GetResult();
-        assert.equal("/**\n * @brief \n * \n * @tparam T \n * @tparam Args \n *"
+        assert.strictEqual("/**\n * @brief \n * \n * @tparam T \n * @tparam Args \n *"
             + " @param first \n * @param args \n * @return T \n */", result);
     });
 
     test("Default template param value", () => {
         const result = testSetup.SetLine("template <bool is_foo=false, bool is_bar =true, bool is_nothrow = true>"
             + "\nstruct Foo;").GetResult();
-        assert.equal("/**\n * @brief \n * \n * @tparam is_foo \n * @tparam is_bar \n *"
+        assert.strictEqual("/**\n * @brief \n * \n * @tparam is_foo \n * @tparam is_bar \n *"
             + " @tparam is_nothrow \n */", result);
     });
 });

--- a/src/test/CppTests/TrailingReturns.test.ts
+++ b/src/test/CppTests/TrailingReturns.test.ts
@@ -18,22 +18,22 @@ suite("C++ - Trailing returns tests", () => {
     // tests
     test("Trailing return", () => {
         const result = testSetup.SetLine("auto foo() -> int;").GetResult();
-        assert.equal("/**\n * @brief \n * \n * @return int \n */", result);
+        assert.strictEqual("/**\n * @brief \n * \n * @return int \n */", result);
     });
 
     test("Trailing return with decltype", () => {
         const result = testSetup.SetLine("auto foo(int a, double b) -> decltype(a + b);").GetResult();
-        assert.equal("/**\n * @brief \n * \n * @param a \n * @param b \n * @return decltype(a + b) \n */", result);
+        assert.strictEqual("/**\n * @brief \n * \n * @param a \n * @param b \n * @return decltype(a + b) \n */", result);
     });
 
     test("Multiple trailing returns", () => {
         const result = testSetup.SetLine("auto foo() -> auto(*)() -> tmp<int>(*)();").GetResult();
-        assert.equal("/**\n * @brief \n * \n * @return auto(*)() -> tmp<int>(*)() \n */", result);
+        assert.strictEqual("/**\n * @brief \n * \n * @return auto(*)() -> tmp<int>(*)() \n */", result);
     });
 
     test("Trailing return with keywords", () => {
         const result = testSetup.SetLine("auto foo(const int& a, const double* b) const noexcept -> const double&;")
             .GetResult();
-        assert.equal("/**\n * @brief \n * \n * @param a \n * @param b \n * @return const double& \n */", result);
+        assert.strictEqual("/**\n * @brief \n * \n * @param a \n * @param b \n * @return const double& \n */", result);
     });
 });


### PR DESCRIPTION
Due to message: deprecated since v9.9.0 - use strictEqual() instead.

# Fix/Feature/Other

## Fix

- [ ] Link to issue. If there is no issue please describe it using at least the issue template
Due to message: deprecated since v9.9.0 - use strictEqual() instead.
- [ ] Description of the fix

- [ ] Added unit test

## Feature

- [ ] Description of what's added

- [ ] Gif of your feature if appropriate

- [ ] Added gif to README

- [ ] Added unit test

## Other

- [ ] Description
