### PR TITLE
Fix tags in generic order not expanded

### DIFF
--- a/src/Lang/Cpp/CppDocGen.ts
+++ b/src/Lang/Cpp/CppDocGen.ts
@@ -298,27 +298,7 @@ export class CppDocGen implements IDocGen {
         return params;
     }
 
-    /**
-     * Get author info, possibly using info from git config
-     */
-    private getAuthorInfo() {
-        let authorName: string = this.cfg.Generic.authorName;
-        let authorEmail: string = this.cfg.Generic.authorEmail;
 
-        // Check if set to use the git username
-        if (this.cfg.Generic.useGitUserName === true) {
-            authorName = this.gitConfig.UserName;
-        }
-
-        // Check if set to use the git email
-        if (this.cfg.Generic.useGitUserEmail === true) {
-            authorEmail = this.gitConfig.UserEmail;
-        }
-        return {
-            authorName,
-            authorEmail
-        };
-    }
 
     protected generateAuthorTag(lines: string[]) {
         if (this.cfg.Generic.authorTag.trim().length !== 0) {
@@ -398,15 +378,14 @@ export class CppDocGen implements IDocGen {
         }
     }
 
-
-
     protected generateCustomTag(lines: string[], target = CommentType.file) {
         let dateFormat: string = "YYYY-MM-DD"; // Default to ISO standard if not defined
         if ( this.cfg.Generic.dateFormat.trim().length !== 0) {
             dateFormat = this.cfg.Generic.dateFormat; // Overwrite with user format
         }
 
-        // Have to check this setting, otherwise {author} and {email} will get incorrect result if useGitUserName and useGitUserEmail is used
+        // Have to check this setting, otherwise {author} and {email} will get incorrect result 
+        // if useGitUserName and useGitUserEmail is used
         const authorInfo = this.getAuthorInfo();
 
         const targetTagArray = target === CommentType.file ? this.cfg.File.customTag : this.cfg.Generic.customTags;
@@ -593,5 +572,27 @@ export class CppDocGen implements IDocGen {
         }
 
         return vals.join(" ");
+    }
+
+    /**
+     * Get author info, possibly using info from git config
+     */
+    private getAuthorInfo() {
+        let authorName: string = this.cfg.Generic.authorName;
+        let authorEmail: string = this.cfg.Generic.authorEmail;
+
+        // Check if set to use the git username
+        if (this.cfg.Generic.useGitUserName === true) {
+            authorName = this.gitConfig.UserName;
+        }
+
+        // Check if set to use the git email
+        if (this.cfg.Generic.useGitUserEmail === true) {
+            authorEmail = this.gitConfig.UserEmail;
+        }
+        return {
+            authorEmail,
+            authorName,
+        };
     }
 }

--- a/src/Lang/Cpp/CppDocGen.ts
+++ b/src/Lang/Cpp/CppDocGen.ts
@@ -507,6 +507,22 @@ export class CppDocGen implements IDocGen {
                     });
                     break;
                 }
+                case "version": {
+                    this.generateVersionTag(lines);
+                    break;
+                }
+                case "author": {
+                    this.generateAuthorTag(lines);
+                    break;
+                }
+                case "date": {
+                    this.generateDateFromTemplate(lines);
+                    break;
+                }
+                case "copyright": {
+                    this.generateCopyrightTag(lines);
+                    break;
+                }
                 default: {
                     break;
                 }

--- a/src/Lang/Cpp/CppDocGen.ts
+++ b/src/Lang/Cpp/CppDocGen.ts
@@ -298,8 +298,6 @@ export class CppDocGen implements IDocGen {
         return params;
     }
 
-
-
     protected generateAuthorTag(lines: string[]) {
         if (this.cfg.Generic.authorTag.trim().length !== 0) {
             const authorInfo = this.getAuthorInfo();
@@ -384,7 +382,7 @@ export class CppDocGen implements IDocGen {
             dateFormat = this.cfg.Generic.dateFormat; // Overwrite with user format
         }
 
-        // Have to check this setting, otherwise {author} and {email} will get incorrect result 
+        // Have to check this setting, otherwise {author} and {email} will get incorrect result
         // if useGitUserName and useGitUserEmail is used
         const authorInfo = this.getAuthorInfo();
 

--- a/src/Lang/Cpp/CppDocGen.ts
+++ b/src/Lang/Cpp/CppDocGen.ts
@@ -396,7 +396,7 @@ export class CppDocGen implements IDocGen {
         const targetTagArray = target === CommentType.file ? this.cfg.File.customTag : this.cfg.Generic.customTags;
         // For each line of the customTag
         targetTagArray.forEach((element) => {
-            if(element !== "custom") { // Prevent recursive expansion
+            if (element !== "custom") { // Prevent recursive expansion
                 // Allow any of date, year, author, email to be replaced
                 lines.push(
                     ...this.getMultiTemplatedString(
@@ -451,7 +451,7 @@ export class CppDocGen implements IDocGen {
                     break;
                 }
                 case "custom": {
-                    this.generateCustomTag(lines,CommentType.file);
+                    this.generateCustomTag(lines, CommentType.file);
                     break;
                 }
                 default: {

--- a/src/test/CppTests/Config.test.ts
+++ b/src/test/CppTests/Config.test.ts
@@ -241,13 +241,13 @@ suite("C++ - Configuration Tests", () => {
         testSetup.cfg.Generic.customTags = [
             "@author {author}",
             "@date {date}",
-            "@note {email}"
+            "@note {email}",
         ];
         testSetup.cfg.Generic.useGitUserName = true;
         testSetup.cfg.Generic.useGitUserEmail = true;
         const result = testSetup.SetLine("void foo();").GetResult();
         assert.notStrictEqual("/**\n * @author {author}\n * @date {date}\n * @note {email}\n */", result);
-    })
+    });
 
     test("Env variable", () => {
         testSetup.cfg = new Config();

--- a/src/test/CppTests/Config.test.ts
+++ b/src/test/CppTests/Config.test.ts
@@ -235,6 +235,20 @@ suite("C++ - Configuration Tests", () => {
         assert.strictEqual("/**\n * @note\n */", result);
     });
 
+    test("Custom tag expansion in function", () => {
+        testSetup.cfg = new Config();
+        testSetup.cfg.Generic.order = ["custom"];
+        testSetup.cfg.Generic.customTags = [
+            "@author {author}",
+            "@date {date}",
+            "@note {email}"
+        ];
+        testSetup.cfg.Generic.useGitUserName = true;
+        testSetup.cfg.Generic.useGitUserEmail = true;
+        const result = testSetup.SetLine("void foo();").GetResult();
+        assert.notStrictEqual("/**\n * @author {author}\n * @date {date}\n * @note {email}\n */", result);
+    })
+
     test("Env variable", () => {
         testSetup.cfg = new Config();
         testSetup.cfg.Generic.order = ["custom"];


### PR DESCRIPTION
# Fix/Feature/Other

## Fix

- [ ] Link to issue.
This closes #204 

- [ ] Description of the fix
~~Copied file-scoped tag branches -> generic tag branches, so it can be properly expanded.~~
The common tags that can be used in both `File` comments and `Method` comments are handled by one same function. So it can be both expanded properly.
![genericTags](https://user-images.githubusercontent.com/42881734/116768652-d8791000-aa6a-11eb-9021-1eca9fd2e95c.gif)

