### PR TITLE
fix indent not expanded in file comments

### DIFF
--- a/src/DoxygenCompletionItemProvider.ts
+++ b/src/DoxygenCompletionItemProvider.ts
@@ -14,7 +14,7 @@ export default class DoxygenCompletionItemProvider implements vscode.CompletionI
         ["arg", "${1:item-description}", "Generate a simple, non-nested list of arguments"],
         ["b", "${1:word}", "Display `<word>` in bold"],
         ["c", "${1:word}", "Display `<word>` using a typewriter font"],
-        ["code", "${1:language-id}\n${2:code}\n@endcode", "Starts a block of code"], // TODO: match end block symbol with trigger character
+        ["code", "{.${1:language-id}}\n${2:code}\n@endcode", "Starts a block of code"], // TODO: match end block symbol with trigger character
         ["copydoc", "${1:link-object}", "Copy a documentation block from the object specified by `<link-object>` and paste it at the location of the command. The link object can point to a member (of a class, file or group), a class, a namespace, a group, a page, or a file. If the member is overloaded, you should specify the argument types explicitly"],
         ["copybrief", "${1:link-object}", "Work in a similar way as `@copydoc` but will only copy the brief description, not the detailed documentation"],
         ["copydetails", "${1:link-object}", "Work in a similar way as `@copydoc` but will only copy the detailed documentation, not the brief description"],

--- a/src/Lang/Cpp/CppDocGen.ts
+++ b/src/Lang/Cpp/CppDocGen.ts
@@ -250,7 +250,7 @@ export class CppDocGen implements IDocGen {
 
     protected generateVersionTag(lines: string[]) {
         if (this.cfg.File.versionTag.trim().length !== 0) {
-            lines.push(...this.cfg.File.versionTag.split("\n"));
+            lines.push(...templates.getIndentedTemplate(this.cfg.File.versionTag).split("\n"));
         }
     }
 

--- a/src/templatedString.ts
+++ b/src/templatedString.ts
@@ -80,5 +80,5 @@ export function getMultiTemplatedString(
     for (const template of templates) {
         original = original.replace(template.toReplace, template.with);
     }
-    return getEnvVars(original);
+    return getEnvVars(getIndentedTemplate(original));
 }

--- a/src/test/CppTests/Config.test.ts
+++ b/src/test/CppTests/Config.test.ts
@@ -93,7 +93,7 @@ suite("C++ - Configuration Tests", () => {
             + " * @return true \n * @return false \n */");
     });
 
-    test("Indentation test", () => {
+    test("Function comment indentation test", () => {
         testSetup.cfg = new Config();
         let result = testSetup.SetLine("\ttemplate<typename T> bool foo(T a);").GetResult();
         assert.strictEqual(result, "/**\n\t * @brief \n\t * \n\t * @tparam T \n\t * @param a \n\t * "
@@ -103,6 +103,32 @@ suite("C++ - Configuration Tests", () => {
         assert.strictEqual(result, "/**\n           * @brief \n           * \n           * @tparam T "
             + "\n           * @param a \n           * "
             + "@return true \n           * @return false \n           */");
+    });
+
+    test("File comment indentation test", () => {
+        testSetup.cfg.File.fileOrder = [
+            "file",
+            "author",
+            "brief",
+            "version",
+            "date",
+            "copyright",
+        ];
+        testSetup.cfg.File.fileTemplate = "@file{indent:10}{name}";
+        testSetup.cfg.Generic.authorTag = "@author{indent:10}{author}";
+        testSetup.cfg.Generic.briefTemplate = "@brief{indent:10}Thing";
+        testSetup.cfg.File.versionTag = "@version{indent:10}0.1";
+        testSetup.cfg.Generic.dateTemplate = "@date{indent:10}date";
+        testSetup.cfg.File.copyrightTag = ["@copyright{indent:10}Copyright(c)"];
+        const result = testSetup.SetLine("").GetResult();
+        assert.strictEqual(result, `/**
+ * @file     MockDocument.h
+ * @author   your name
+ * @brief    Thing
+ * @version  0.1
+ * @date     date
+ * @copyrightCopyright(c)
+ */`);
     });
 
     test("Lines to get test", () => {


### PR DESCRIPTION
# Fix/Feature/Other

## Fix

- [ ] Link to issue. If there is no issue please describe it using at least the issue template
Closes #206 

## Feature

- [ ] Added unit test

Also the `@code` command needs `{.cpp}` instead of `.cpp` as the language id block, see [here](https://www.doxygen.nl/manual/commands.html#cmdcode), my bad!