### PR TITLE
Use vscode.workspace.workspaceFolders[0] to construct SimpleGit instance.

### DIFF
--- a/src/GitConfig.ts
+++ b/src/GitConfig.ts
@@ -1,10 +1,17 @@
-import simpleGit, {ConfigValues, SimpleGit} from "simple-git";
+import simpleGit, { ConfigValues, SimpleGit } from "simple-git";
+import { workspace } from "vscode";
 
 export default class GitConfig {
     private gitConfig: ConfigValues;
 
     public constructor() {
-        const git: SimpleGit = simpleGit();
+        let git: SimpleGit;
+        try {
+            git = simpleGit(workspace.workspaceFolders?.[0].uri.fsPath);
+        } catch (error) {
+            git = simpleGit();
+        }
+
         git.listConfig().then((result) => {
             this.gitConfig = result.all;
         });


### PR DESCRIPTION
# Feature

Or is it a fix...

Allows a per-workspace git user and email address.

Note that this change doesn't cope with multiple workspaces in a single vscode instance. It would probably have to defer the config lookup and use the appropriate workspace root for the file being edited at that point.

Thanks for the extension, hope this is useful and it should at least be good for most cases!

Regards
