### PR TITLE
Change Language identifier for CUDA to correct one

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     }
   ],
   "activationEvents": [
-    "onLanguage:cuda",
+    "onLanguage:cuda-cpp",
     "onLanguage:cpp",
     "onLanguage:c"
   ],

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     }
   ],
   "activationEvents": [
+    "onLanguage:cuda",
     "onLanguage:cuda-cpp",
     "onLanguage:cpp",
     "onLanguage:c"

--- a/src/CodeParserController.ts
+++ b/src/CodeParserController.ts
@@ -104,6 +104,7 @@ export default class CodeParserController {
         switch (lang) {
             case "c":
             case "cpp":
+            case "cuda":
             case "cuda-cpp":
                 parser = new CppParser(this.cfg);
                 break;

--- a/src/CodeParserController.ts
+++ b/src/CodeParserController.ts
@@ -104,7 +104,7 @@ export default class CodeParserController {
         switch (lang) {
             case "c":
             case "cpp":
-            case "cuda":
+            case "cuda-cpp":
                 parser = new CppParser(this.cfg);
                 break;
             default:


### PR DESCRIPTION
## Fix

- Issue: doxdocgen is not triggered for CUDA files because the current [language identifier](https://code.visualstudio.com/docs/languages/identifiers) in the `activationEvents` triggers is `cuda` but this is not correct because on the [VS Code website](https://code.visualstudio.com/docs/languages/identifiers) it lists `cuda-cpp` for CUDA &mdash;this issue was mainly noticed because doxdocgen was not working in CUDA files (.cu, .cuh).

- Fix: CUDA support is added again by correcting the language identifier to the &mdash;at this time&mdash; correct value.
