### PR TITLE
README: Use syntax highlighter that allows comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,8 @@ Each of them can be configured with its own custom text and you can decide if th
 
 ## Config options
 
-```json
+```jsonc
+{
   // The prefix that is used for each comment line except for first and last.
   "doxdocgen.c.commentPrefix": " * ",
 
@@ -240,6 +241,7 @@ Each of them can be configured with its own custom text and you can decide if th
 
   // Add `\\` in doxygen command suggestion for better readbility (need to enable commandSuggestion)
   "doxdocgen.generic.commandSuggestionAddPrefix": false
+}
 ```
 
 ## Contributors


### PR DESCRIPTION
Use the `jsonc` instead of the `json` syntax highlighter in the README
to avoid the comments being marked as error.

The GitHub syntax highlighter seems to have parsing issues with the use
of comment tokens `/**` and `*/` within strings: it thinks those are
JSON comments, even though they are normal strings. Converting the JSON
fragment into a full JSON document with curly braces at the beginning
and end brings the parser back on track and gets us the right syntax
highlighting.