### PR TITLE
Allow substitution of "{date}" in @author tag.

### DIFF
--- a/src/Lang/Cpp/CppDocGen.ts
+++ b/src/Lang/Cpp/CppDocGen.ts
@@ -222,6 +222,10 @@ export class CppDocGen implements IDocGen {
     }
 
     protected generateAuthorTag(lines: string[]) {
+        let dateFormat: string = "YYYY-MM-DD"; // Default to ISO standard if not defined
+        if ( this.cfg.Generic.dateFormat.trim().length !== 0) {
+            dateFormat = this.cfg.Generic.dateFormat; // Overwrite with user format
+        }
         if (this.cfg.Generic.authorTag.trim().length !== 0) {
             const authorInfo = this.getAuthorInfo();
             // Allow substitution of {author} and {email} only
@@ -231,6 +235,7 @@ export class CppDocGen implements IDocGen {
                     [
                         { toReplace: this.cfg.authorTemplateReplace, with: authorInfo.authorName },
                         { toReplace: this.cfg.emailTemplateReplace, with: authorInfo.authorEmail },
+                        { toReplace: this.cfg.dateTemplateReplace, with: moment().format(dateFormat) },
                     ],
                 ).split("\n"),
             );

--- a/src/Lang/Cpp/CppDocGen.ts
+++ b/src/Lang/Cpp/CppDocGen.ts
@@ -228,7 +228,7 @@ export class CppDocGen implements IDocGen {
         }
         if (this.cfg.Generic.authorTag.trim().length !== 0) {
             const authorInfo = this.getAuthorInfo();
-            // Allow substitution of {author} and {email} only
+            // Allow substitution of {author}, {email}, and {date} only
             lines.push(
                 ...templates.getMultiTemplatedString(
                     this.cfg.Generic.authorTag,


### PR DESCRIPTION
# Feature

- [x] Description of what's added

In addition to `{author}` and `{email}`, this PR adds `{date}` to the `@author` tag.

- [ ] Added gif to README

- [ ] Added unit test
